### PR TITLE
Allow rules_openscad to fetch a version of OpenSCAD from the repository

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,3 +22,15 @@ py_binary(
         ":scad_utils",
     ],
 )
+
+alias(
+    name = "openscad",
+    actual = select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@openscad_linux_x86_64//:files",
+        "@bazel_tools//src/conditions:linux_aarch64": "@openscad_linux_aarch64//:files",
+        # Add the following lines when we support MacOS and Windows
+        # "@bazel_tools//src/conditions:darwin" : ":openscad_darwin",
+        # "@bazel_tools//src/conditions:windows" : ":openscad_windows",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,3 +3,30 @@ module(
     version = "0.1",
     compatibility_level = 0,
 )
+
+# Here are the files being defined for each OS
+http_appimage = use_repo_rule("//:http_appimage.bzl", "http_appimage")
+http_appimage(
+    name = "openscad_linux_x86_64",
+    url = "https://files.openscad.org/snapshots/OpenSCAD-2024.09.20.ai20452-x86_64.AppImage",
+    sha256 = "eb5bfcc0a19df3016e3e00f3e135695020371c24f2a8629bf1e096009bef8a47",
+)
+http_appimage(
+    name = "openscad_linux_aarch64",
+    url = "https://files.openscad.org/snapshots/OpenSCAD-2023.09.11.ai-aarch64.AppImage",
+    sha256 = "84d7bb1c71e14b4e248a84fbe0a4b02f58bcbf5326f0ee81c8a4de3653a3b568",
+)
+# This is the code that will be required once we support MacOS and Windows
+# http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+# http_file(
+#     name = "openscad_windows_",
+#     executable = True,
+#     url = "https://files.openscad.org/snapshots/OpenSCAD-2024.09.20-x86-64.zip",
+#     sha256 = "6ae4f92fc3fb4bf38efe1a7029f03f018707b376f954d886a635dc41bb6b0ccd",
+# )
+# http_file(
+#     name = "openscad_darwin",
+#     executable = True,
+#     url = "https://files.openscad.org/snapshots/OpenSCAD-2024.09.20.dmg",
+#     sha256 = "8ca81fe343d359b52b058d3c8cff2ac0673f508691a3270c64d8c22ef4beb3f0",
+# )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,2 @@
+load("openscad_files.bzl", "define_openscad_versions")
+define_openscad_versions()

--- a/http_appimage.bzl
+++ b/http_appimage.bzl
@@ -1,0 +1,51 @@
+# Repository rule to fetch an AppImage file from a URL and extract it into a
+# directory
+def _http_appimage_impl(ctx):
+    downloaded_file_path = "files/download"
+    ctx.download(
+        url = [ctx.attr.url],
+        output = downloaded_file_path,
+        sha256 = ctx.attr.sha256,
+        executable = True,
+    )
+    ctx.execute([downloaded_file_path, "--appimage-extract"])
+    ctx.file(
+        "WORKSPACE",
+        "workspace(name = \"{name}\")".format(name = ctx.name),
+    )
+    ctx.file(
+        "BUILD",
+        """
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "files",
+    srcs = glob(["**"]),
+)
+"""
+    )
+
+http_appimage = repository_rule(
+    implementation = _http_appimage_impl,
+    attrs = {
+        "sha256": attr.string(
+            doc = """The expected SHA-256 of the file downloaded
+
+This must match the SHA-256 of the file downloaded. It is a security risk to
+omit the SHA-256 as remote files can change. At best omitting this field will
+make your build non-hermetic. It is optional to make development easier but
+should be set before shipping
+""",
+        ),
+        "url": attr.string(
+            doc = """A URL to a file that will be made available to Bazel
+
+This must be a file, http or https URL. Redirections are followed.
+Authentication is not supported
+
+More flexibility can be achieved by the urls parameter that allows to specify
+alternative URLs to fetch from
+""",
+        ),
+    },
+)

--- a/openscad_files.bzl
+++ b/openscad_files.bzl
@@ -1,0 +1,13 @@
+load("//:http_appimage.bzl", "http_appimage")
+
+def define_openscad_versions():
+    http_appimage(
+        name = "openscad_linux_x86_64",
+        url = "https://files.openscad.org/snapshots/OpenSCAD-2024.09.20.ai20452-x86_64.AppImage",
+        sha256 = "eb5bfcc0a19df3016e3e00f3e135695020371c24f2a8629bf1e096009bef8a47",
+    )
+    http_appimage(
+        name = "openscad_linux_aarch64",
+        url = "https://files.openscad.org/snapshots/OpenSCAD-2023.09.11.ai-aarch64.AppImage",
+        sha256 = "84d7bb1c71e14b4e248a84fbe0a4b02f58bcbf5326f0ee81c8a4de3653a3b568",
+    )

--- a/test_models/WORKSPACE
+++ b/test_models/WORKSPACE
@@ -2,3 +2,6 @@ local_repository(
     name = "rules_openscad",
     path = "../",
 )
+
+load("@rules_openscad//:openscad_files.bzl", "define_openscad_versions")
+define_openscad_versions()

--- a/test_models/testdata/cylinder_section/cylinder_section.stl
+++ b/test_models/testdata/cylinder_section/cylinder_section.stl
@@ -1,254 +1,254 @@
 solid OpenSCAD_Model
-  facet normal 0.982287 0.187384 0
-    outer loop
-      vertex 9.92115 1.25333 5
-      vertex 9.68583 2.4869 0
-      vertex 9.68583 2.4869 5
-    endloop
-  endfacet
-  facet normal 0.982287 0.187384 0
-    outer loop
-      vertex 9.68583 2.4869 0
-      vertex 9.92115 1.25333 5
-      vertex 9.92115 1.25333 0
-    endloop
-  endfacet
-  facet normal 0.998027 0.0627883 0
+  facet normal 0.99802667 0.06279102 0
     outer loop
       vertex 10 0 5
-      vertex 9.92115 1.25333 0
-      vertex 9.92115 1.25333 5
+      vertex 9.921146 1.2533321 0
+      vertex 9.921146 1.2533321 5
     endloop
   endfacet
-  facet normal 0.998027 0.0627883 0
+  facet normal 0.99802667 0.06279102 0
     outer loop
-      vertex 9.92115 1.25333 0
+      vertex 9.921146 1.2533321 0
       vertex 10 0 5
       vertex 10 0 0
     endloop
   endfacet
-  facet normal 0.951055 0.309021 0
+  facet normal 0.99802667 -0.06279102 0
     outer loop
-      vertex 9.68583 2.4869 5
-      vertex 9.29776 3.68124 0
-      vertex 9.29776 3.68124 5
-    endloop
-  endfacet
-  facet normal 0.951055 0.309021 0
-    outer loop
-      vertex 9.29776 3.68124 0
-      vertex 9.68583 2.4869 5
-      vertex 9.68583 2.4869 0
-    endloop
-  endfacet
-  facet normal 0.904843 -0.425745 0
-    outer loop
-      vertex 9.23081 -3.82353 5
-      vertex 9.29776 -3.68124 0
-      vertex 9.29776 -3.68124 5
-    endloop
-  endfacet
-  facet normal 0.904843 -0.425745 0
-    outer loop
-      vertex 9.29776 -3.68124 0
-      vertex 9.23081 -3.82353 5
-      vertex 9.23081 -3.82353 0
-    endloop
-  endfacet
-  facet normal 0.904843 0.425745 0
-    outer loop
-      vertex 9.29776 3.68124 5
-      vertex 9.23081 3.82353 0
-      vertex 9.23081 3.82353 5
-    endloop
-  endfacet
-  facet normal 0.904843 0.425745 0
-    outer loop
-      vertex 9.23081 3.82353 0
-      vertex 9.29776 3.68124 5
-      vertex 9.29776 3.68124 0
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 9.29776 -3.68124 5
-      vertex 9.68583 -2.4869 0
-      vertex 9.68583 -2.4869 5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 9.68583 -2.4869 0
-      vertex 9.29776 -3.68124 5
-      vertex 9.29776 -3.68124 0
-    endloop
-  endfacet
-  facet normal 0.998027 -0.0627883 0
-    outer loop
-      vertex 9.92115 -1.25333 5
+      vertex 9.921146 -1.2533321 5
       vertex 10 0 0
       vertex 10 0 5
     endloop
   endfacet
-  facet normal 0.998027 -0.0627883 0
+  facet normal 0.99802667 -0.06279102 0
     outer loop
       vertex 10 0 0
-      vertex 9.92115 -1.25333 5
-      vertex 9.92115 -1.25333 0
+      vertex 9.921146 -1.2533321 5
+      vertex 9.921146 -1.2533321 0
+    endloop
+  endfacet
+  facet normal 0.90482736 0.42577863 0
+    outer loop
+      vertex 9.297765 3.6812449 5
+      vertex 9.230812 3.8235269 0
+      vertex 9.230812 3.8235269 5
+    endloop
+  endfacet
+  facet normal 0.90482736 0.42577863 0
+    outer loop
+      vertex 9.230812 3.8235269 0
+      vertex 9.297765 3.6812449 5
+      vertex 9.297765 3.6812449 0
+    endloop
+  endfacet
+  facet normal 0.90482736 -0.42577863 0
+    outer loop
+      vertex 9.230812 -3.8235269 5
+      vertex 9.297765 -3.6812449 0
+      vertex 9.297765 -3.6812449 5
+    endloop
+  endfacet
+  facet normal 0.90482736 -0.42577863 0
+    outer loop
+      vertex 9.297765 -3.6812449 0
+      vertex 9.230812 -3.8235269 5
+      vertex 9.230812 -3.8235269 0
+    endloop
+  endfacet
+  facet normal 0.9822872 0.1873813 0
+    outer loop
+      vertex 9.921146 1.2533321 5
+      vertex 9.685831 2.4868984 0
+      vertex 9.685831 2.4868984 5
+    endloop
+  endfacet
+  facet normal 0.9822872 0.1873813 0
+    outer loop
+      vertex 9.685831 2.4868984 0
+      vertex 9.921146 1.2533321 5
+      vertex 9.921146 1.2533321 0
+    endloop
+  endfacet
+  facet normal 0.9510566 0.3090167 0
+    outer loop
+      vertex 9.685831 2.4868984 5
+      vertex 9.297765 3.6812449 0
+      vertex 9.297765 3.6812449 5
+    endloop
+  endfacet
+  facet normal 0.9510566 0.3090167 0
+    outer loop
+      vertex 9.297765 3.6812449 0
+      vertex 9.685831 2.4868984 5
+      vertex 9.685831 2.4868984 0
+    endloop
+  endfacet
+  facet normal 0.9510566 -0.3090167 0
+    outer loop
+      vertex 9.297765 -3.6812449 5
+      vertex 9.685831 -2.4868984 0
+      vertex 9.685831 -2.4868984 5
+    endloop
+  endfacet
+  facet normal 0.9510566 -0.3090167 0
+    outer loop
+      vertex 9.685831 -2.4868984 0
+      vertex 9.297765 -3.6812449 5
+      vertex 9.297765 -3.6812449 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex 0 0 0
       vertex 10 0 0
-      vertex 9.92115 -1.25333 0
+      vertex 9.921146 -1.2533321 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex 0 0 0
-      vertex 9.92115 -1.25333 0
-      vertex 9.68583 -2.4869 0
+      vertex 9.921146 -1.2533321 0
+      vertex 9.685831 -2.4868984 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex 10 0 0
       vertex 0 0 0
-      vertex 9.92115 1.25333 0
+      vertex 9.921146 1.2533321 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex 0 0 0
-      vertex 9.68583 -2.4869 0
-      vertex 9.29776 -3.68124 0
+      vertex 9.685831 -2.4868984 0
+      vertex 9.297765 -3.6812449 0
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 -1
     outer loop
-      vertex 9.92115 1.25333 0
+      vertex 9.921146 1.2533321 0
       vertex 0 0 0
-      vertex 9.68583 2.4869 0
+      vertex 9.685831 2.4868984 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex 0 0 0
-      vertex 9.29776 -3.68124 0
-      vertex 9.23081 -3.82353 0
+      vertex 9.297765 -3.6812449 0
+      vertex 9.230812 -3.8235269 0
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 -1
     outer loop
-      vertex 9.68583 2.4869 0
+      vertex 9.685831 2.4868984 0
       vertex 0 0 0
-      vertex 9.29776 3.68124 0
+      vertex 9.297765 3.6812449 0
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 -1
     outer loop
-      vertex 9.29776 3.68124 0
+      vertex 9.297765 3.6812449 0
       vertex 0 0 0
-      vertex 9.23081 3.82353 0
-    endloop
-  endfacet
-  facet normal 0.982287 -0.187384 0
-    outer loop
-      vertex 9.68583 -2.4869 5
-      vertex 9.92115 -1.25333 0
-      vertex 9.92115 -1.25333 5
-    endloop
-  endfacet
-  facet normal 0.982287 -0.187384 0
-    outer loop
-      vertex 9.92115 -1.25333 0
-      vertex 9.68583 -2.4869 5
-      vertex 9.68583 -2.4869 0
+      vertex 9.230812 3.8235269 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 0 0 5
       vertex 10 0 5
-      vertex 9.92115 1.25333 5
+      vertex 9.921146 1.2533321 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 0 0 5
-      vertex 9.92115 1.25333 5
-      vertex 9.68583 2.4869 5
+      vertex 9.921146 1.2533321 5
+      vertex 9.685831 2.4868984 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 10 0 5
       vertex 0 0 5
-      vertex 9.92115 -1.25333 5
+      vertex 9.921146 -1.2533321 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 0 0 5
-      vertex 9.68583 2.4869 5
-      vertex 9.29776 3.68124 5
+      vertex 9.685831 2.4868984 5
+      vertex 9.297765 3.6812449 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.92115 -1.25333 5
+      vertex 9.921146 -1.2533321 5
       vertex 0 0 5
-      vertex 9.68583 -2.4869 5
+      vertex 9.685831 -2.4868984 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 0 0 5
-      vertex 9.29776 3.68124 5
-      vertex 9.23081 3.82353 5
+      vertex 9.297765 3.6812449 5
+      vertex 9.230812 3.8235269 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.68583 -2.4869 5
+      vertex 9.685831 -2.4868984 5
       vertex 0 0 5
-      vertex 9.29776 -3.68124 5
+      vertex 9.297765 -3.6812449 5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.29776 -3.68124 5
+      vertex 9.297765 -3.6812449 5
       vertex 0 0 5
-      vertex 9.23081 -3.82353 5
+      vertex 9.230812 -3.8235269 5
     endloop
   endfacet
-  facet normal -0.382684 0.923879 0
+  facet normal 0.9822872 -0.1873813 0
     outer loop
-      vertex 9.23081 3.82353 0
-      vertex 0 0 5
-      vertex 9.23081 3.82353 5
+      vertex 9.685831 -2.4868984 5
+      vertex 9.921146 -1.2533321 0
+      vertex 9.921146 -1.2533321 5
     endloop
   endfacet
-  facet normal -0.382684 0.923879 0
+  facet normal 0.9822872 -0.1873813 0
+    outer loop
+      vertex 9.921146 -1.2533321 0
+      vertex 9.685831 -2.4868984 5
+      vertex 9.685831 -2.4868984 0
+    endloop
+  endfacet
+  facet normal -0.38268337 0.92387956 0
+    outer loop
+      vertex 9.230812 3.8235269 0
+      vertex 0 0 5
+      vertex 9.230812 3.8235269 5
+    endloop
+  endfacet
+  facet normal -0.38268337 0.92387956 0
     outer loop
       vertex 0 0 5
-      vertex 9.23081 3.82353 0
+      vertex 9.230812 3.8235269 0
       vertex 0 0 0
     endloop
   endfacet
-  facet normal -0.382684 -0.923879 0
+  facet normal -0.38268337 -0.92387956 0
     outer loop
       vertex 0 0 0
-      vertex 9.23081 -3.82353 5
+      vertex 9.230812 -3.8235269 5
       vertex 0 0 5
     endloop
   endfacet
-  facet normal -0.382684 -0.923879 -0
+  facet normal -0.38268337 -0.92387956 0
     outer loop
-      vertex 9.23081 -3.82353 5
+      vertex 9.230812 -3.8235269 5
       vertex 0 0 0
-      vertex 9.23081 -3.82353 0
+      vertex 9.230812 -3.8235269 0
     endloop
   endfacet
 endsolid OpenSCAD_Model

--- a/test_models/testdata/hardware/m2_nut.stl
+++ b/test_models/testdata/hardware/m2_nut.stl
@@ -1,142 +1,142 @@
 solid OpenSCAD_Model
-  facet normal 0.866026 0.5 0
+  facet normal 0.8660254 0.5 0
     outer loop
       vertex 2.325 0 2.6
-      vertex 1.1625 2.01351 0
-      vertex 1.1625 2.01351 2.6
+      vertex 1.1625 2.013509 0
+      vertex 1.1625 2.013509 2.6
     endloop
   endfacet
-  facet normal 0.866026 0.5 0
+  facet normal 0.8660254 0.5 0
     outer loop
-      vertex 1.1625 2.01351 0
+      vertex 1.1625 2.013509 0
       vertex 2.325 0 2.6
       vertex 2.325 0 0
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.1625 2.01351 0
-      vertex -1.1625 2.01351 2.6
-      vertex 1.1625 2.01351 2.6
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -1.1625 2.01351 2.6
-      vertex 1.1625 2.01351 0
-      vertex -1.1625 2.01351 0
+      vertex 1.1625 2.013509 0
+      vertex -1.1625 2.013509 2.6
+      vertex 1.1625 2.013509 2.6
     endloop
   endfacet
-  facet normal -0.866026 0.5 0
+  facet normal 0 1 0
     outer loop
-      vertex -2.325 -0 0
-      vertex -1.1625 2.01351 2.6
-      vertex -1.1625 2.01351 0
+      vertex -1.1625 2.013509 2.6
+      vertex 1.1625 2.013509 0
+      vertex -1.1625 2.013509 0
     endloop
   endfacet
-  facet normal -0.866026 0.5 0
+  facet normal -0.8660254 0.5 0
     outer loop
-      vertex -1.1625 2.01351 2.6
-      vertex -2.325 -0 0
-      vertex -2.325 -0 2.6
+      vertex -2.325 0 0
+      vertex -1.1625 2.013509 2.6
+      vertex -1.1625 2.013509 0
     endloop
   endfacet
-  facet normal -0.866026 -0.5 0
+  facet normal -0.8660254 0.5 0
     outer loop
-      vertex -1.1625 -2.01351 0
-      vertex -2.325 -0 2.6
-      vertex -2.325 -0 0
+      vertex -1.1625 2.013509 2.6
+      vertex -2.325 0 0
+      vertex -2.325 0 2.6
     endloop
   endfacet
-  facet normal -0.866026 -0.5 0
+  facet normal -0.8660254 -0.5 0
     outer loop
-      vertex -2.325 -0 2.6
-      vertex -1.1625 -2.01351 0
-      vertex -1.1625 -2.01351 2.6
+      vertex -1.1625 -2.013509 0
+      vertex -2.325 0 2.6
+      vertex -2.325 0 0
+    endloop
+  endfacet
+  facet normal -0.8660254 -0.5 0
+    outer loop
+      vertex -2.325 0 2.6
+      vertex -1.1625 -2.013509 0
+      vertex -1.1625 -2.013509 2.6
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -1.1625 -2.01351 0
-      vertex 1.1625 -2.01351 2.6
-      vertex -1.1625 -2.01351 2.6
+      vertex -1.1625 -2.013509 0
+      vertex 1.1625 -2.013509 2.6
+      vertex -1.1625 -2.013509 2.6
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 -1 0
     outer loop
-      vertex 1.1625 -2.01351 2.6
-      vertex -1.1625 -2.01351 0
-      vertex 1.1625 -2.01351 0
+      vertex 1.1625 -2.013509 2.6
+      vertex -1.1625 -2.013509 0
+      vertex 1.1625 -2.013509 0
     endloop
   endfacet
-  facet normal 0.866026 -0.5 0
+  facet normal 0.8660254 -0.5 0
     outer loop
-      vertex 1.1625 -2.01351 2.6
+      vertex 1.1625 -2.013509 2.6
       vertex 2.325 0 0
       vertex 2.325 0 2.6
     endloop
   endfacet
-  facet normal 0.866026 -0.5 0
+  facet normal 0.8660254 -0.5 0
     outer loop
       vertex 2.325 0 0
-      vertex 1.1625 -2.01351 2.6
-      vertex 1.1625 -2.01351 0
+      vertex 1.1625 -2.013509 2.6
+      vertex 1.1625 -2.013509 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 1.1625 -2.01351 0
-      vertex 1.1625 2.01351 0
+      vertex 1.1625 -2.013509 0
+      vertex 1.1625 2.013509 0
       vertex 2.325 0 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.1625 -2.01351 0
-      vertex 1.1625 2.01351 0
-      vertex 1.1625 -2.01351 0
+      vertex -1.1625 -2.013509 0
+      vertex 1.1625 2.013509 0
+      vertex 1.1625 -2.013509 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.1625 -2.01351 0
-      vertex -1.1625 2.01351 0
-      vertex 1.1625 2.01351 0
+      vertex -1.1625 -2.013509 0
+      vertex -1.1625 2.013509 0
+      vertex 1.1625 2.013509 0
     endloop
   endfacet
-  facet normal 0 -0 -1
+  facet normal 0 0 -1
     outer loop
-      vertex -1.1625 2.01351 0
-      vertex -1.1625 -2.01351 0
-      vertex -2.325 -0 0
+      vertex -1.1625 2.013509 0
+      vertex -1.1625 -2.013509 0
+      vertex -2.325 0 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.1625 2.01351 2.6
-      vertex 1.1625 -2.01351 2.6
+      vertex 1.1625 2.013509 2.6
+      vertex 1.1625 -2.013509 2.6
       vertex 2.325 0 2.6
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.1625 2.01351 2.6
-      vertex 1.1625 -2.01351 2.6
-      vertex 1.1625 2.01351 2.6
+      vertex -1.1625 2.013509 2.6
+      vertex 1.1625 -2.013509 2.6
+      vertex 1.1625 2.013509 2.6
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.1625 2.01351 2.6
-      vertex -1.1625 -2.01351 2.6
-      vertex 1.1625 -2.01351 2.6
+      vertex -1.1625 2.013509 2.6
+      vertex -1.1625 -2.013509 2.6
+      vertex 1.1625 -2.013509 2.6
     endloop
   endfacet
-  facet normal 0 -0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.1625 -2.01351 2.6
-      vertex -1.1625 2.01351 2.6
-      vertex -2.325 -0 2.6
+      vertex -1.1625 -2.013509 2.6
+      vertex -1.1625 2.013509 2.6
+      vertex -2.325 0 2.6
     endloop
   endfacet
 endsolid OpenSCAD_Model

--- a/test_models/testdata/hollow_cylinder/ed_id.stl
+++ b/test_models/testdata/hollow_cylinder/ed_id.stl
@@ -1,2802 +1,2802 @@
 solid OpenSCAD_Model
-  facet normal 0.982284 0.187396 0
+  facet normal 0.77051324 0.637424 0
     outer loop
-      vertex 1.48817 0.188 10
-      vertex 1.45287 0.373034 0
-      vertex 1.45287 0.373034 10
+      vertex 1.2135248 0.8816776 10
+      vertex 1.0934525 1.0268202 0
+      vertex 1.0934525 1.0268202 10
     endloop
   endfacet
-  facet normal 0.982284 0.187396 0
+  facet normal 0.77051324 0.637424 0
     outer loop
-      vertex 1.45287 0.373034 0
-      vertex 1.48817 0.188 10
-      vertex 1.48817 0.188 0
+      vertex 1.0934525 1.0268202 0
+      vertex 1.2135248 0.8816776 10
+      vertex 1.2135248 0.8816776 0
     endloop
   endfacet
-  facet normal 0.998026 0.0628013 0
+  facet normal 0.24869178 0.9685827 0
+    outer loop
+      vertex 0.46352482 1.4265842 0
+      vertex 0.28107166 1.4734306 10
+      vertex 0.46352482 1.4265842 10
+    endloop
+  endfacet
+  facet normal 0.24869178 0.9685827 0
+    outer loop
+      vertex 0.28107166 1.4734306 10
+      vertex 0.46352482 1.4265842 0
+      vertex 0.28107166 1.4734306 0
+    endloop
+  endfacet
+  facet normal 0.99802655 0.06279307 0
     outer loop
       vertex 1.5 0 10
-      vertex 1.48817 0.188 0
-      vertex 1.48817 0.188 10
+      vertex 1.4881716 0.18799973 0
+      vertex 1.4881716 0.18799973 10
     endloop
   endfacet
-  facet normal 0.998026 0.0628013 0
+  facet normal 0.99802655 0.06279307 0
     outer loop
-      vertex 1.48817 0.188 0
+      vertex 1.4881716 0.18799973 0
       vertex 1.5 0 10
       vertex 1.5 0 0
     endloop
   endfacet
-  facet normal 0.904838 0.425756 0
+  facet normal 0.48175356 -0.8763068 0
     outer loop
-      vertex 1.39466 0.552186 10
-      vertex 1.31446 0.722631 0
-      vertex 1.31446 0.722631 10
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.63866806 -1.3572397 10
     endloop
   endfacet
-  facet normal 0.904838 0.425756 0
+  facet normal 0.48175356 -0.8763068 0
     outer loop
-      vertex 1.31446 0.722631 0
-      vertex 1.39466 0.552186 10
-      vertex 1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal 0.684557 0.728959 -0
-    outer loop
-      vertex 1.09345 1.02682 0
-      vertex 0.956136 1.15577 10
-      vertex 1.09345 1.02682 10
-    endloop
-  endfacet
-  facet normal 0.684557 0.728959 0
-    outer loop
-      vertex 0.956136 1.15577 10
-      vertex 1.09345 1.02682 0
-      vertex 0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal 0.24871 0.968578 -0
-    outer loop
-      vertex 0.463525 1.42658 0
-      vertex 0.281072 1.47343 10
-      vertex 0.463525 1.42658 10
-    endloop
-  endfacet
-  facet normal 0.24871 0.968578 0
-    outer loop
-      vertex 0.281072 1.47343 10
-      vertex 0.463525 1.42658 0
-      vertex 0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0.998026 -0.0628013 0
-    outer loop
-      vertex 1.48817 -0.188 10
-      vertex 1.5 0 0
-      vertex 1.5 0 10
-    endloop
-  endfacet
-  facet normal 0.998026 -0.0628013 0
-    outer loop
-      vertex 1.5 0 0
-      vertex 1.48817 -0.188 10
-      vertex 1.48817 -0.188 0
-    endloop
-  endfacet
-  facet normal 0.904838 -0.425756 0
-    outer loop
-      vertex 1.31446 -0.722631 10
-      vertex 1.39466 -0.552186 0
-      vertex 1.39466 -0.552186 10
-    endloop
-  endfacet
-  facet normal 0.904838 -0.425756 0
-    outer loop
-      vertex 1.39466 -0.552186 0
-      vertex 1.31446 -0.722631 10
-      vertex 1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal -0.587778 -0.809022 0
-    outer loop
-      vertex -0.956136 -1.15577 0
-      vertex -0.80374 -1.26649 10
-      vertex -0.956136 -1.15577 10
-    endloop
-  endfacet
-  facet normal -0.587778 -0.809022 -0
-    outer loop
-      vertex -0.80374 -1.26649 10
-      vertex -0.956136 -1.15577 0
-      vertex -0.80374 -1.26649 0
-    endloop
-  endfacet
-  facet normal 0.368106 -0.929784 0
-    outer loop
-      vertex 0.463525 -1.42658 0
-      vertex 0.638668 -1.35724 10
-      vertex 0.463525 -1.42658 10
-    endloop
-  endfacet
-  facet normal 0.368106 -0.929784 0
-    outer loop
-      vertex 0.638668 -1.35724 10
-      vertex 0.463525 -1.42658 0
-      vertex 0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal -0.844314 -0.535848 0
-    outer loop
-      vertex -1.21352 -0.881678 0
-      vertex -1.31446 -0.722631 10
-      vertex -1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal -0.844314 -0.535848 0
-    outer loop
-      vertex -1.31446 -0.722631 10
-      vertex -1.21352 -0.881678 0
-      vertex -1.21352 -0.881678 10
-    endloop
-  endfacet
-  facet normal 0.368106 0.929784 -0
-    outer loop
-      vertex 0.638668 1.35724 0
-      vertex 0.463525 1.42658 10
-      vertex 0.638668 1.35724 10
-    endloop
-  endfacet
-  facet normal 0.368106 0.929784 0
-    outer loop
-      vertex 0.463525 1.42658 10
-      vertex 0.638668 1.35724 0
-      vertex 0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal -0.481757 0.876305 0
-    outer loop
-      vertex -0.638668 1.35724 0
-      vertex -0.80374 1.26649 10
-      vertex -0.638668 1.35724 10
-    endloop
-  endfacet
-  facet normal -0.481757 0.876305 0
-    outer loop
-      vertex -0.80374 1.26649 10
-      vertex -0.638668 1.35724 0
-      vertex -0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 1.45287 0.373034 10
-      vertex 1.39466 0.552186 0
-      vertex 1.39466 0.552186 10
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 1.39466 0.552186 0
-      vertex 1.45287 0.373034 10
-      vertex 1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal 0.982284 -0.187396 0
-    outer loop
-      vertex 1.45287 -0.373034 10
-      vertex 1.48817 -0.188 0
-      vertex 1.48817 -0.188 10
-    endloop
-  endfacet
-  facet normal 0.982284 -0.187396 0
-    outer loop
-      vertex 1.48817 -0.188 0
-      vertex 1.45287 -0.373034 10
-      vertex 1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal 0.481757 0.876305 -0
-    outer loop
-      vertex 0.80374 1.26649 0
-      vertex 0.638668 1.35724 10
-      vertex 0.80374 1.26649 10
-    endloop
-  endfacet
-  facet normal 0.481757 0.876305 0
-    outer loop
-      vertex 0.638668 1.35724 10
-      vertex 0.80374 1.26649 0
-      vertex 0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0.125337 -0.992114 0
-    outer loop
-      vertex 0.0941849 -1.49704 0
-      vertex 0.281072 -1.47343 10
-      vertex 0.0941849 -1.49704 10
-    endloop
-  endfacet
-  facet normal 0.125337 -0.992114 0
-    outer loop
-      vertex 0.281072 -1.47343 10
-      vertex 0.0941849 -1.49704 0
-      vertex 0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -1.45287 0.373034 0
-      vertex -1.39466 0.552186 10
-      vertex -1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -1.39466 0.552186 10
-      vertex -1.45287 0.373034 0
-      vertex -1.45287 0.373034 10
-    endloop
-  endfacet
-  facet normal 0.844314 0.535848 0
-    outer loop
-      vertex 1.31446 0.722631 10
-      vertex 1.21352 0.881678 0
-      vertex 1.21352 0.881678 10
-    endloop
-  endfacet
-  facet normal 0.844314 0.535848 0
-    outer loop
-      vertex 1.21352 0.881678 0
-      vertex 1.31446 0.722631 10
-      vertex 1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex 1.39466 -0.552186 10
-      vertex 1.45287 -0.373034 0
-      vertex 1.45287 -0.373034 10
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex 1.45287 -0.373034 0
-      vertex 1.39466 -0.552186 10
-      vertex 1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal -0.684557 0.728959 0
-    outer loop
-      vertex -0.956136 1.15577 0
-      vertex -1.09345 1.02682 10
-      vertex -0.956136 1.15577 10
-    endloop
-  endfacet
-  facet normal -0.684557 0.728959 0
-    outer loop
-      vertex -1.09345 1.02682 10
-      vertex -0.956136 1.15577 0
-      vertex -1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal 0.24871 -0.968578 0
-    outer loop
-      vertex 0.281072 -1.47343 0
-      vertex 0.463525 -1.42658 10
-      vertex 0.281072 -1.47343 10
-    endloop
-  endfacet
-  facet normal 0.24871 -0.968578 0
-    outer loop
-      vertex 0.463525 -1.42658 10
-      vertex 0.281072 -1.47343 0
-      vertex 0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal -0.368106 0.929784 0
-    outer loop
-      vertex -0.463525 1.42658 0
-      vertex -0.638668 1.35724 10
-      vertex -0.463525 1.42658 10
-    endloop
-  endfacet
-  facet normal -0.368106 0.929784 0
-    outer loop
-      vertex -0.638668 1.35724 10
-      vertex -0.463525 1.42658 0
-      vertex -0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0.125337 0.992114 -0
-    outer loop
-      vertex 0.281072 1.47343 0
-      vertex 0.0941849 1.49704 10
-      vertex 0.281072 1.47343 10
-    endloop
-  endfacet
-  facet normal 0.125337 0.992114 0
-    outer loop
-      vertex 0.0941849 1.49704 10
-      vertex 0.281072 1.47343 0
-      vertex 0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal -0.24871 0.968578 0
-    outer loop
-      vertex -0.281072 1.47343 0
-      vertex -0.463525 1.42658 10
-      vertex -0.281072 1.47343 10
-    endloop
-  endfacet
-  facet normal -0.24871 0.968578 0
-    outer loop
-      vertex -0.463525 1.42658 10
-      vertex -0.281072 1.47343 0
-      vertex -0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal -0.982284 -0.187396 0
-    outer loop
-      vertex -1.45287 -0.373034 0
-      vertex -1.48817 -0.188 10
-      vertex -1.48817 -0.188 0
-    endloop
-  endfacet
-  facet normal -0.982284 -0.187396 0
-    outer loop
-      vertex -1.48817 -0.188 10
-      vertex -1.45287 -0.373034 0
-      vertex -1.45287 -0.373034 10
-    endloop
-  endfacet
-  facet normal 0.587778 0.809022 -0
-    outer loop
-      vertex 0.956136 1.15577 0
-      vertex 0.80374 1.26649 10
-      vertex 0.956136 1.15577 10
-    endloop
-  endfacet
-  facet normal 0.587778 0.809022 0
-    outer loop
-      vertex 0.80374 1.26649 10
-      vertex 0.956136 1.15577 0
-      vertex 0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal -0.998026 -0.0628013 0
-    outer loop
-      vertex -1.48817 -0.188 0
-      vertex -1.5 0 10
-      vertex -1.5 0 0
-    endloop
-  endfacet
-  facet normal -0.998026 -0.0628013 0
-    outer loop
-      vertex -1.5 0 10
-      vertex -1.48817 -0.188 0
-      vertex -1.48817 -0.188 10
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.80373955 -1.2664909 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 0.5 0 10
       vertex 1.5 0 10
-      vertex 1.48817 0.188 10
+      vertex 1.4881716 0.18799973 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.496057 0.0626659 10
-      vertex 1.48817 0.188 10
-      vertex 1.45287 0.373034 10
+      vertex 0.49605656 0.06266594 10
+      vertex 1.4881716 0.18799973 10
+      vertex 1.4528742 0.37303448 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 1.5 0 10
       vertex 0.5 0 10
-      vertex 1.48817 -0.188 10
+      vertex 1.4881716 -0.18799973 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.484291 0.124345 10
-      vertex 1.45287 0.373034 10
-      vertex 1.39466 0.552186 10
+      vertex 0.48429108 0.124344826 10
+      vertex 1.4528742 0.37303448 10
+      vertex 1.3946638 0.552186 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.496057 -0.0626659 10
-      vertex 1.48817 -0.188 10
+      vertex 0.49605656 -0.06266594 10
+      vertex 1.4881716 -0.18799973 10
       vertex 0.5 0 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.464888 0.184062 10
-      vertex 1.39466 0.552186 10
-      vertex 1.31446 0.722631 10
+      vertex 0.46488762 0.184062 10
+      vertex 1.3946638 0.552186 10
+      vertex 1.3144598 0.7226305 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.48817 -0.188 10
-      vertex 0.496057 -0.0626659 10
-      vertex 1.45287 -0.373034 10
+      vertex 1.4881716 -0.18799973 10
+      vertex 0.49605656 -0.06266594 10
+      vertex 1.4528742 -0.37303448 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.438153 0.240876 10
-      vertex 1.31446 0.722631 10
-      vertex 1.21352 0.881678 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.484291 -0.124345 10
-      vertex 1.45287 -0.373034 10
-      vertex 0.496057 -0.0626659 10
+      vertex 0.43815327 0.2408762 10
+      vertex 1.3144598 0.7226305 10
+      vertex 1.2135248 0.8816776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.404508 0.293892 10
-      vertex 1.21352 0.881678 10
-      vertex 1.09345 1.02682 10
+      vertex 0.48429108 -0.124344826 10
+      vertex 1.4528742 -0.37303448 10
+      vertex 0.49605656 -0.06266594 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.45287 -0.373034 10
-      vertex 0.484291 -0.124345 10
-      vertex 1.39466 -0.552186 10
+      vertex 0.40450764 0.2938919 10
+      vertex 1.2135248 0.8816776 10
+      vertex 1.0934525 1.0268202 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.364484 0.342273 10
-      vertex 1.09345 1.02682 10
-      vertex 0.956136 1.15577 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.464888 -0.184062 10
-      vertex 1.39466 -0.552186 10
-      vertex 0.484291 -0.124345 10
+      vertex 1.4528742 -0.37303448 10
+      vertex 0.48429108 -0.124344826 10
+      vertex 1.3946638 -0.552186 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.318711 0.385256 10
-      vertex 0.956136 1.15577 10
-      vertex 0.80374 1.26649 10
+      vertex 0.36448383 0.34227276 10
+      vertex 1.0934525 1.0268202 10
+      vertex 0.95613575 1.1557693 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.39466 -0.552186 10
-      vertex 0.464888 -0.184062 10
-      vertex 1.31446 -0.722631 10
+      vertex 0.46488762 -0.184062 10
+      vertex 1.3946638 -0.552186 10
+      vertex 0.48429108 -0.124344826 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.267913 0.422163 10
-      vertex 0.80374 1.26649 10
-      vertex 0.638668 1.35724 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.438153 -0.240876 10
-      vertex 1.31446 -0.722631 10
-      vertex 0.464888 -0.184062 10
+      vertex 0.31871128 0.3852558 10
+      vertex 0.95613575 1.1557693 10
+      vertex 0.80373955 1.2664909 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.31446 -0.722631 10
-      vertex 0.438153 -0.240876 10
-      vertex 1.21352 -0.881678 10
+      vertex 1.3946638 -0.552186 10
+      vertex 0.46488762 -0.184062 10
+      vertex 1.3144598 -0.7226305 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.48817 0.188 10
-      vertex 0.496057 0.0626659 10
+      vertex 0.26791286 0.422163 10
+      vertex 0.80373955 1.2664909 10
+      vertex 0.63866806 1.3572397 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.43815327 -0.2408762 10
+      vertex 1.3144598 -0.7226305 10
+      vertex 0.46488762 -0.184062 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.3144598 -0.7226305 10
+      vertex 0.43815327 -0.2408762 10
+      vertex 1.2135248 -0.8816776 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.4881716 0.18799973 10
+      vertex 0.49605656 0.06266594 10
       vertex 0.5 0 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.45287 0.373034 10
-      vertex 0.484291 0.124345 10
-      vertex 0.496057 0.0626659 10
+      vertex 1.4528742 0.37303448 10
+      vertex 0.48429108 0.124344826 10
+      vertex 0.49605656 0.06266594 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.39466 0.552186 10
-      vertex 0.464888 0.184062 10
-      vertex 0.484291 0.124345 10
+      vertex 1.3946638 0.552186 10
+      vertex 0.46488762 0.184062 10
+      vertex 0.48429108 0.124344826 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.212889 0.452413 10
-      vertex 0.638668 1.35724 10
-      vertex 0.463525 1.42658 10
+      vertex 0.21288872 0.4524126 10
+      vertex 0.63866806 1.3572397 10
+      vertex 0.46352482 1.4265842 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.31446 0.722631 10
-      vertex 0.438153 0.240876 10
-      vertex 0.464888 0.184062 10
+      vertex 1.3144598 0.7226305 10
+      vertex 0.43815327 0.2408762 10
+      vertex 0.46488762 0.184062 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.21352 0.881678 10
-      vertex 0.404508 0.293892 10
-      vertex 0.438153 0.240876 10
+      vertex 1.2135248 0.8816776 10
+      vertex 0.40450764 0.2938919 10
+      vertex 0.43815327 0.2408762 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.09345 1.02682 10
-      vertex 0.364484 0.342273 10
-      vertex 0.404508 0.293892 10
+      vertex 1.0934525 1.0268202 10
+      vertex 0.36448383 0.34227276 10
+      vertex 0.40450764 0.2938919 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.956136 1.15577 10
-      vertex 0.318711 0.385256 10
-      vertex 0.364484 0.342273 10
+      vertex 0.95613575 1.1557693 10
+      vertex 0.31871128 0.3852558 10
+      vertex 0.36448383 0.34227276 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.154508 0.475528 10
-      vertex 0.463525 1.42658 10
-      vertex 0.281072 1.47343 10
+      vertex 0.15450764 0.47552776 10
+      vertex 0.46352482 1.4265842 10
+      vertex 0.28107166 1.4734306 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.80374 1.26649 10
-      vertex 0.267913 0.422163 10
-      vertex 0.318711 0.385256 10
+      vertex 0.80373955 1.2664909 10
+      vertex 0.26791286 0.422163 10
+      vertex 0.31871128 0.3852558 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.638668 1.35724 10
-      vertex 0.212889 0.452413 10
-      vertex 0.267913 0.422163 10
+      vertex 0.63866806 1.3572397 10
+      vertex 0.21288872 0.4524126 10
+      vertex 0.26791286 0.422163 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.463525 1.42658 10
-      vertex 0.154508 0.475528 10
-      vertex 0.212889 0.452413 10
+      vertex 0.46352482 1.4265842 10
+      vertex 0.15450764 0.47552776 10
+      vertex 0.21288872 0.4524126 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.0936899 0.491143 10
-      vertex 0.281072 1.47343 10
-      vertex 0.0941849 1.49704 10
+      vertex 0.09368992 0.49114323 10
+      vertex 0.28107166 1.4734306 10
+      vertex 0.094184875 1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.281072 1.47343 10
-      vertex 0.0936899 0.491143 10
-      vertex 0.154508 0.475528 10
+      vertex 0.28107166 1.4734306 10
+      vertex 0.09368992 0.49114323 10
+      vertex 0.15450764 0.47552776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.0941849 1.49704 10
-      vertex 0.031395 0.499013 10
-      vertex 0.0936899 0.491143 10
+      vertex 0.094184875 1.4970398 10
+      vertex 0.03139496 0.49901295 10
+      vertex 0.09368992 0.49114323 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.0941849 1.49704 10
-      vertex -0.031395 0.499013 10
-      vertex 0.031395 0.499013 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.0941849 1.49704 10
-      vertex -0.031395 0.499013 10
-      vertex 0.0941849 1.49704 10
+      vertex 0.094184875 1.4970398 10
+      vertex -0.03139496 0.49901295 10
+      vertex 0.03139496 0.49901295 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.031395 0.499013 10
-      vertex -0.0941849 1.49704 10
-      vertex -0.0936899 0.491143 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.281072 1.47343 10
-      vertex -0.0936899 0.491143 10
-      vertex -0.0941849 1.49704 10
+      vertex -0.094184875 1.4970398 10
+      vertex -0.03139496 0.49901295 10
+      vertex 0.094184875 1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.0936899 0.491143 10
-      vertex -0.281072 1.47343 10
-      vertex -0.154508 0.475528 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.463525 1.42658 10
-      vertex -0.154508 0.475528 10
-      vertex -0.281072 1.47343 10
+      vertex -0.03139496 0.49901295 10
+      vertex -0.094184875 1.4970398 10
+      vertex -0.09368992 0.49114323 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.154508 0.475528 10
-      vertex -0.463525 1.42658 10
-      vertex -0.212889 0.452413 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.638668 1.35724 10
-      vertex -0.212889 0.452413 10
-      vertex -0.463525 1.42658 10
+      vertex -0.28107166 1.4734306 10
+      vertex -0.09368992 0.49114323 10
+      vertex -0.094184875 1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.212889 0.452413 10
-      vertex -0.638668 1.35724 10
-      vertex -0.267913 0.422163 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.80374 1.26649 10
-      vertex -0.267913 0.422163 10
-      vertex -0.638668 1.35724 10
+      vertex -0.09368992 0.49114323 10
+      vertex -0.28107166 1.4734306 10
+      vertex -0.15450764 0.47552776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.267913 0.422163 10
-      vertex -0.80374 1.26649 10
-      vertex -0.318711 0.385256 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.956136 1.15577 10
-      vertex -0.318711 0.385256 10
-      vertex -0.80374 1.26649 10
+      vertex -0.46352482 1.4265842 10
+      vertex -0.15450764 0.47552776 10
+      vertex -0.28107166 1.4734306 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.318711 0.385256 10
-      vertex -0.956136 1.15577 10
-      vertex -0.364484 0.342273 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.09345 1.02682 10
-      vertex -0.364484 0.342273 10
-      vertex -0.956136 1.15577 10
+      vertex -0.15450764 0.47552776 10
+      vertex -0.46352482 1.4265842 10
+      vertex -0.21288872 0.4524126 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.364484 0.342273 10
-      vertex -1.09345 1.02682 10
-      vertex -0.404508 0.293892 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.21352 0.881678 10
-      vertex -0.404508 0.293892 10
-      vertex -1.09345 1.02682 10
+      vertex -0.63866806 1.3572397 10
+      vertex -0.21288872 0.4524126 10
+      vertex -0.46352482 1.4265842 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.404508 0.293892 10
-      vertex -1.21352 0.881678 10
-      vertex -0.438153 0.240876 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.404508 -0.293892 10
-      vertex 1.21352 -0.881678 10
-      vertex 0.438153 -0.240876 10
+      vertex -0.21288872 0.4524126 10
+      vertex -0.63866806 1.3572397 10
+      vertex -0.26791286 0.422163 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.21352 -0.881678 10
-      vertex 0.404508 -0.293892 10
-      vertex 1.09345 -1.02682 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.364484 -0.342273 10
-      vertex 1.09345 -1.02682 10
-      vertex 0.404508 -0.293892 10
+      vertex -0.80373955 1.2664909 10
+      vertex -0.26791286 0.422163 10
+      vertex -0.63866806 1.3572397 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.09345 -1.02682 10
-      vertex 0.364484 -0.342273 10
-      vertex 0.956136 -1.15577 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.318711 -0.385256 10
-      vertex 0.956136 -1.15577 10
-      vertex 0.364484 -0.342273 10
+      vertex -0.26791286 0.422163 10
+      vertex -0.80373955 1.2664909 10
+      vertex -0.31871128 0.3852558 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.956136 -1.15577 10
-      vertex 0.318711 -0.385256 10
-      vertex 0.80374 -1.26649 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.267913 -0.422163 10
-      vertex 0.80374 -1.26649 10
-      vertex 0.318711 -0.385256 10
+      vertex -0.95613575 1.1557693 10
+      vertex -0.31871128 0.3852558 10
+      vertex -0.80373955 1.2664909 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.80374 -1.26649 10
-      vertex 0.267913 -0.422163 10
-      vertex 0.638668 -1.35724 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.212889 -0.452413 10
-      vertex 0.638668 -1.35724 10
-      vertex 0.267913 -0.422163 10
+      vertex -0.31871128 0.3852558 10
+      vertex -0.95613575 1.1557693 10
+      vertex -0.36448383 0.34227276 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.638668 -1.35724 10
-      vertex 0.212889 -0.452413 10
-      vertex 0.463525 -1.42658 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.154508 -0.475528 10
-      vertex 0.463525 -1.42658 10
-      vertex 0.212889 -0.452413 10
+      vertex -1.0934525 1.0268202 10
+      vertex -0.36448383 0.34227276 10
+      vertex -0.95613575 1.1557693 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.463525 -1.42658 10
-      vertex 0.154508 -0.475528 10
-      vertex 0.281072 -1.47343 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.0936899 -0.491143 10
-      vertex 0.281072 -1.47343 10
-      vertex 0.154508 -0.475528 10
+      vertex -0.36448383 0.34227276 10
+      vertex -1.0934525 1.0268202 10
+      vertex -0.40450764 0.2938919 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.281072 -1.47343 10
-      vertex 0.0936899 -0.491143 10
-      vertex 0.0941849 -1.49704 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.031395 -0.499013 10
-      vertex 0.0941849 -1.49704 10
-      vertex 0.0936899 -0.491143 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.031395 -0.499013 10
-      vertex 0.0941849 -1.49704 10
-      vertex 0.031395 -0.499013 10
+      vertex -1.2135248 0.8816776 10
+      vertex -0.40450764 0.2938919 10
+      vertex -1.0934525 1.0268202 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.0941849 -1.49704 10
-      vertex -0.031395 -0.499013 10
-      vertex -0.0936899 -0.491143 10
+      vertex -0.40450764 0.2938919 10
+      vertex -1.2135248 0.8816776 10
+      vertex -0.43815327 0.2408762 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.031395 -0.499013 10
-      vertex -0.0941849 -1.49704 10
-      vertex 0.0941849 -1.49704 10
+      vertex 0.40450764 -0.2938919 10
+      vertex 1.2135248 -0.8816776 10
+      vertex 0.43815327 -0.2408762 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.281072 -1.47343 10
-      vertex -0.0936899 -0.491143 10
-      vertex -0.154508 -0.475528 10
+      vertex 1.2135248 -0.8816776 10
+      vertex 0.40450764 -0.2938919 10
+      vertex 1.0934525 -1.0268202 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.463525 -1.42658 10
-      vertex -0.154508 -0.475528 10
-      vertex -0.212889 -0.452413 10
+      vertex 0.36448383 -0.34227276 10
+      vertex 1.0934525 -1.0268202 10
+      vertex 0.40450764 -0.2938919 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.638668 -1.35724 10
-      vertex -0.212889 -0.452413 10
-      vertex -0.267913 -0.422163 10
+      vertex 1.0934525 -1.0268202 10
+      vertex 0.36448383 -0.34227276 10
+      vertex 0.95613575 -1.1557693 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.0936899 -0.491143 10
-      vertex -0.281072 -1.47343 10
-      vertex -0.0941849 -1.49704 10
+      vertex 0.31871128 -0.3852558 10
+      vertex 0.95613575 -1.1557693 10
+      vertex 0.36448383 -0.34227276 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.80374 -1.26649 10
-      vertex -0.267913 -0.422163 10
-      vertex -0.318711 -0.385256 10
+      vertex 0.95613575 -1.1557693 10
+      vertex 0.31871128 -0.3852558 10
+      vertex 0.80373955 -1.2664909 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.956136 -1.15577 10
-      vertex -0.318711 -0.385256 10
-      vertex -0.364484 -0.342273 10
+      vertex 0.26791286 -0.422163 10
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.31871128 -0.3852558 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.09345 -1.02682 10
-      vertex -0.364484 -0.342273 10
-      vertex -0.404508 -0.293892 10
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.26791286 -0.422163 10
+      vertex 0.63866806 -1.3572397 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.21352 -0.881678 10
-      vertex -0.404508 -0.293892 10
-      vertex -0.438153 -0.240876 10
+      vertex 0.21288872 -0.4524126 10
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.26791286 -0.422163 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.154508 -0.475528 10
-      vertex -0.463525 -1.42658 10
-      vertex -0.281072 -1.47343 10
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.21288872 -0.4524126 10
+      vertex 0.46352482 -1.4265842 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.31446 -0.722631 10
-      vertex -0.438153 -0.240876 10
-      vertex -0.464888 -0.184062 10
+      vertex 0.15450764 -0.47552776 10
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.21288872 -0.4524126 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.39466 -0.552186 10
-      vertex -0.464888 -0.184062 10
-      vertex -0.484291 -0.124345 10
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.15450764 -0.47552776 10
+      vertex 0.28107166 -1.4734306 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.45287 -0.373034 10
-      vertex -0.484291 -0.124345 10
-      vertex -0.496057 -0.0626659 10
+      vertex 0.09368992 -0.49114323 10
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.15450764 -0.47552776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.48817 -0.188 10
-      vertex -0.496057 -0.0626659 10
-      vertex -0.5 0 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.31446 0.722631 10
-      vertex -0.438153 0.240876 10
-      vertex -1.21352 0.881678 10
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.09368992 -0.49114323 10
+      vertex 0.094184875 -1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.212889 -0.452413 10
-      vertex -0.638668 -1.35724 10
-      vertex -0.463525 -1.42658 10
+      vertex 0.03139496 -0.49901295 10
+      vertex 0.094184875 -1.4970398 10
+      vertex 0.09368992 -0.49114323 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.438153 0.240876 10
-      vertex -1.31446 0.722631 10
-      vertex -0.464888 0.184062 10
+      vertex -0.03139496 -0.49901295 10
+      vertex 0.094184875 -1.4970398 10
+      vertex 0.03139496 -0.49901295 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.267913 -0.422163 10
-      vertex -0.80374 -1.26649 10
-      vertex -0.638668 -1.35724 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.39466 0.552186 10
-      vertex -0.464888 0.184062 10
-      vertex -1.31446 0.722631 10
+      vertex -0.094184875 -1.4970398 10
+      vertex -0.03139496 -0.49901295 10
+      vertex -0.09368992 -0.49114323 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.318711 -0.385256 10
-      vertex -0.956136 -1.15577 10
-      vertex -0.80374 -1.26649 10
+      vertex -0.03139496 -0.49901295 10
+      vertex -0.094184875 -1.4970398 10
+      vertex 0.094184875 -1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.464888 0.184062 10
-      vertex -1.39466 0.552186 10
-      vertex -0.484291 0.124345 10
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.09368992 -0.49114323 10
+      vertex -0.15450764 -0.47552776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.364484 -0.342273 10
-      vertex -1.09345 -1.02682 10
-      vertex -0.956136 -1.15577 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.45287 0.373034 10
-      vertex -0.484291 0.124345 10
-      vertex -1.39466 0.552186 10
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.15450764 -0.47552776 10
+      vertex -0.21288872 -0.4524126 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.404508 -0.293892 10
-      vertex -1.21352 -0.881678 10
-      vertex -1.09345 -1.02682 10
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.21288872 -0.4524126 10
+      vertex -0.26791286 -0.422163 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.484291 0.124345 10
-      vertex -1.45287 0.373034 10
-      vertex -0.496057 0.0626659 10
+      vertex -0.09368992 -0.49114323 10
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.094184875 -1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.438153 -0.240876 10
-      vertex -1.31446 -0.722631 10
-      vertex -1.21352 -0.881678 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.48817 0.188 10
-      vertex -0.496057 0.0626659 10
-      vertex -1.45287 0.373034 10
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.26791286 -0.422163 10
+      vertex -0.31871128 -0.3852558 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.464888 -0.184062 10
-      vertex -1.39466 -0.552186 10
-      vertex -1.31446 -0.722631 10
+      vertex -0.95613575 -1.1557693 10
+      vertex -0.31871128 -0.3852558 10
+      vertex -0.36448383 -0.34227276 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.496057 0.0626659 10
-      vertex -1.48817 0.188 10
+      vertex -1.0934525 -1.0268202 10
+      vertex -0.36448383 -0.34227276 10
+      vertex -0.40450764 -0.2938919 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.2135248 -0.8816776 10
+      vertex -0.40450764 -0.2938919 10
+      vertex -0.43815327 -0.2408762 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.15450764 -0.47552776 10
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.28107166 -1.4734306 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.3144598 -0.7226305 10
+      vertex -0.43815327 -0.2408762 10
+      vertex -0.46488762 -0.184062 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.3946638 -0.552186 10
+      vertex -0.46488762 -0.184062 10
+      vertex -0.48429108 -0.124344826 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.4528742 -0.37303448 10
+      vertex -0.48429108 -0.124344826 10
+      vertex -0.49605656 -0.06266594 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.4881716 -0.18799973 10
+      vertex -0.49605656 -0.06266594 10
       vertex -0.5 0 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.484291 -0.124345 10
-      vertex -1.45287 -0.373034 10
-      vertex -1.39466 -0.552186 10
+      vertex -1.3144598 0.7226305 10
+      vertex -0.43815327 0.2408762 10
+      vertex -1.2135248 0.8816776 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.21288872 -0.4524126 10
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.46352482 -1.4265842 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.43815327 0.2408762 10
+      vertex -1.3144598 0.7226305 10
+      vertex -0.46488762 0.184062 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.26791286 -0.422163 10
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.63866806 -1.3572397 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.3946638 0.552186 10
+      vertex -0.46488762 0.184062 10
+      vertex -1.3144598 0.7226305 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.31871128 -0.3852558 10
+      vertex -0.95613575 -1.1557693 10
+      vertex -0.80373955 -1.2664909 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.46488762 0.184062 10
+      vertex -1.3946638 0.552186 10
+      vertex -0.48429108 0.124344826 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.36448383 -0.34227276 10
+      vertex -1.0934525 -1.0268202 10
+      vertex -0.95613575 -1.1557693 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.4528742 0.37303448 10
+      vertex -0.48429108 0.124344826 10
+      vertex -1.3946638 0.552186 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.40450764 -0.2938919 10
+      vertex -1.2135248 -0.8816776 10
+      vertex -1.0934525 -1.0268202 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.48429108 0.124344826 10
+      vertex -1.4528742 0.37303448 10
+      vertex -0.49605656 0.06266594 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.43815327 -0.2408762 10
+      vertex -1.3144598 -0.7226305 10
+      vertex -1.2135248 -0.8816776 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.4881716 0.18799973 10
+      vertex -0.49605656 0.06266594 10
+      vertex -1.4528742 0.37303448 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.46488762 -0.184062 10
+      vertex -1.3946638 -0.552186 10
+      vertex -1.3144598 -0.7226305 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.49605656 0.06266594 10
+      vertex -1.4881716 0.18799973 10
+      vertex -0.5 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.48429108 -0.124344826 10
+      vertex -1.4528742 -0.37303448 10
+      vertex -1.3946638 -0.552186 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex -1.5 0 10
       vertex -0.5 0 10
-      vertex -1.48817 0.188 10
+      vertex -1.4881716 0.18799973 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.496057 -0.0626659 10
-      vertex -1.48817 -0.188 10
-      vertex -1.45287 -0.373034 10
+      vertex -0.49605656 -0.06266594 10
+      vertex -1.4881716 -0.18799973 10
+      vertex -1.4528742 -0.37303448 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex -0.5 0 10
       vertex -1.5 0 10
-      vertex -1.48817 -0.188 10
+      vertex -1.4881716 -0.18799973 10
     endloop
   endfacet
-  facet normal 0.481757 -0.876305 0
+  facet normal 0.36812642 -0.9297758 0
     outer loop
-      vertex 0.638668 -1.35724 0
-      vertex 0.80374 -1.26649 10
-      vertex 0.638668 -1.35724 10
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.46352482 -1.4265842 10
     endloop
   endfacet
-  facet normal 0.481757 -0.876305 0
+  facet normal 0.36812642 -0.9297758 0
     outer loop
-      vertex 0.80374 -1.26649 10
-      vertex 0.638668 -1.35724 0
-      vertex 0.80374 -1.26649 0
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.63866806 -1.3572397 0
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0.68454766 -0.7289681 0
     outer loop
-      vertex 0.5 0 0
-      vertex 1.5 0 0
-      vertex 1.48817 -0.188 0
+      vertex -1.0934525 -1.0268202 0
+      vertex -0.95613575 -1.1557693 10
+      vertex -1.0934525 -1.0268202 10
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0.68454766 -0.7289681 0
     outer loop
-      vertex 0.496057 -0.0626659 0
-      vertex 1.48817 -0.188 0
-      vertex 1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.5 0 0
-      vertex 0.5 0 0
-      vertex 1.48817 0.188 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.484291 -0.124345 0
-      vertex 1.45287 -0.373034 0
-      vertex 1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.496057 0.0626659 0
-      vertex 1.48817 0.188 0
-      vertex 0.5 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.464888 -0.184062 0
-      vertex 1.39466 -0.552186 0
-      vertex 1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.48817 0.188 0
-      vertex 0.496057 0.0626659 0
-      vertex 1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.438153 -0.240876 0
-      vertex 1.31446 -0.722631 0
-      vertex 1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.484291 0.124345 0
-      vertex 1.45287 0.373034 0
-      vertex 0.496057 0.0626659 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.404508 -0.293892 0
-      vertex 1.21352 -0.881678 0
-      vertex 1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.45287 0.373034 0
-      vertex 0.484291 0.124345 0
-      vertex 1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.364484 -0.342273 0
-      vertex 1.09345 -1.02682 0
-      vertex 0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.464888 0.184062 0
-      vertex 1.39466 0.552186 0
-      vertex 0.484291 0.124345 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.318711 -0.385256 0
-      vertex 0.956136 -1.15577 0
-      vertex 0.80374 -1.26649 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.39466 0.552186 0
-      vertex 0.464888 0.184062 0
-      vertex 1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.267913 -0.422163 0
-      vertex 0.80374 -1.26649 0
-      vertex 0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.438153 0.240876 0
-      vertex 1.31446 0.722631 0
-      vertex 0.464888 0.184062 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.31446 0.722631 0
-      vertex 0.438153 0.240876 0
-      vertex 1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.48817 -0.188 0
-      vertex 0.496057 -0.0626659 0
-      vertex 0.5 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.45287 -0.373034 0
-      vertex 0.484291 -0.124345 0
-      vertex 0.496057 -0.0626659 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.39466 -0.552186 0
-      vertex 0.464888 -0.184062 0
-      vertex 0.484291 -0.124345 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.212889 -0.452413 0
-      vertex 0.638668 -1.35724 0
-      vertex 0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.31446 -0.722631 0
-      vertex 0.438153 -0.240876 0
-      vertex 0.464888 -0.184062 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.21352 -0.881678 0
-      vertex 0.404508 -0.293892 0
-      vertex 0.438153 -0.240876 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.09345 -1.02682 0
-      vertex 0.364484 -0.342273 0
-      vertex 0.404508 -0.293892 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.956136 -1.15577 0
-      vertex 0.318711 -0.385256 0
-      vertex 0.364484 -0.342273 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.154508 -0.475528 0
-      vertex 0.463525 -1.42658 0
-      vertex 0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.80374 -1.26649 0
-      vertex 0.267913 -0.422163 0
-      vertex 0.318711 -0.385256 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.638668 -1.35724 0
-      vertex 0.212889 -0.452413 0
-      vertex 0.267913 -0.422163 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.463525 -1.42658 0
-      vertex 0.154508 -0.475528 0
-      vertex 0.212889 -0.452413 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0936899 -0.491143 0
-      vertex 0.281072 -1.47343 0
-      vertex 0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.281072 -1.47343 0
-      vertex 0.0936899 -0.491143 0
-      vertex 0.154508 -0.475528 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0941849 -1.49704 0
-      vertex 0.031395 -0.499013 0
-      vertex 0.0936899 -0.491143 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0941849 -1.49704 0
-      vertex -0.031395 -0.499013 0
-      vertex 0.031395 -0.499013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.0941849 -1.49704 0
-      vertex -0.031395 -0.499013 0
-      vertex 0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.031395 -0.499013 0
-      vertex -0.0941849 -1.49704 0
-      vertex -0.0936899 -0.491143 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.281072 -1.47343 0
-      vertex -0.0936899 -0.491143 0
-      vertex -0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.0936899 -0.491143 0
-      vertex -0.281072 -1.47343 0
-      vertex -0.154508 -0.475528 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.463525 -1.42658 0
-      vertex -0.154508 -0.475528 0
-      vertex -0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.154508 -0.475528 0
-      vertex -0.463525 -1.42658 0
-      vertex -0.212889 -0.452413 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.638668 -1.35724 0
-      vertex -0.212889 -0.452413 0
-      vertex -0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.212889 -0.452413 0
-      vertex -0.638668 -1.35724 0
-      vertex -0.267913 -0.422163 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.80374 -1.26649 0
-      vertex -0.267913 -0.422163 0
-      vertex -0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.267913 -0.422163 0
-      vertex -0.80374 -1.26649 0
-      vertex -0.318711 -0.385256 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.956136 -1.15577 0
-      vertex -0.318711 -0.385256 0
-      vertex -0.80374 -1.26649 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.318711 -0.385256 0
-      vertex -0.956136 -1.15577 0
-      vertex -0.364484 -0.342273 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.09345 -1.02682 0
-      vertex -0.364484 -0.342273 0
-      vertex -0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.364484 -0.342273 0
-      vertex -1.09345 -1.02682 0
-      vertex -0.404508 -0.293892 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.21352 -0.881678 0
-      vertex -0.404508 -0.293892 0
-      vertex -1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.404508 -0.293892 0
-      vertex -1.21352 -0.881678 0
-      vertex -0.438153 -0.240876 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.404508 0.293892 0
-      vertex 1.21352 0.881678 0
-      vertex 0.438153 0.240876 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.21352 0.881678 0
-      vertex 0.404508 0.293892 0
-      vertex 1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.364484 0.342273 0
-      vertex 1.09345 1.02682 0
-      vertex 0.404508 0.293892 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.09345 1.02682 0
-      vertex 0.364484 0.342273 0
-      vertex 0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.318711 0.385256 0
-      vertex 0.956136 1.15577 0
-      vertex 0.364484 0.342273 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0.956136 1.15577 0
-      vertex 0.318711 0.385256 0
-      vertex 0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.267913 0.422163 0
-      vertex 0.80374 1.26649 0
-      vertex 0.318711 0.385256 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0.80374 1.26649 0
-      vertex 0.267913 0.422163 0
-      vertex 0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.212889 0.452413 0
-      vertex 0.638668 1.35724 0
-      vertex 0.267913 0.422163 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0.638668 1.35724 0
-      vertex 0.212889 0.452413 0
-      vertex 0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.154508 0.475528 0
-      vertex 0.463525 1.42658 0
-      vertex 0.212889 0.452413 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0.463525 1.42658 0
-      vertex 0.154508 0.475528 0
-      vertex 0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0936899 0.491143 0
-      vertex 0.281072 1.47343 0
-      vertex 0.154508 0.475528 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0.281072 1.47343 0
-      vertex 0.0936899 0.491143 0
-      vertex 0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.031395 0.499013 0
-      vertex 0.0941849 1.49704 0
-      vertex 0.0936899 0.491143 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.031395 0.499013 0
-      vertex 0.0941849 1.49704 0
-      vertex 0.031395 0.499013 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.0941849 1.49704 0
-      vertex -0.031395 0.499013 0
-      vertex -0.0936899 0.491143 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.031395 0.499013 0
-      vertex -0.0941849 1.49704 0
-      vertex 0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.281072 1.47343 0
-      vertex -0.0936899 0.491143 0
-      vertex -0.154508 0.475528 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.463525 1.42658 0
-      vertex -0.154508 0.475528 0
-      vertex -0.212889 0.452413 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.638668 1.35724 0
-      vertex -0.212889 0.452413 0
-      vertex -0.267913 0.422163 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.0936899 0.491143 0
-      vertex -0.281072 1.47343 0
-      vertex -0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.80374 1.26649 0
-      vertex -0.267913 0.422163 0
-      vertex -0.318711 0.385256 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.956136 1.15577 0
-      vertex -0.318711 0.385256 0
-      vertex -0.364484 0.342273 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.09345 1.02682 0
-      vertex -0.364484 0.342273 0
-      vertex -0.404508 0.293892 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.21352 0.881678 0
-      vertex -0.404508 0.293892 0
-      vertex -0.438153 0.240876 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.154508 0.475528 0
-      vertex -0.463525 1.42658 0
-      vertex -0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.31446 0.722631 0
-      vertex -0.438153 0.240876 0
-      vertex -0.464888 0.184062 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.39466 0.552186 0
-      vertex -0.464888 0.184062 0
-      vertex -0.484291 0.124345 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.45287 0.373034 0
-      vertex -0.484291 0.124345 0
-      vertex -0.496057 0.0626659 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.48817 0.188 0
-      vertex -0.496057 0.0626659 0
-      vertex -0.5 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.31446 -0.722631 0
-      vertex -0.438153 -0.240876 0
-      vertex -1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.212889 0.452413 0
-      vertex -0.638668 1.35724 0
-      vertex -0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.438153 -0.240876 0
-      vertex -1.31446 -0.722631 0
-      vertex -0.464888 -0.184062 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.267913 0.422163 0
-      vertex -0.80374 1.26649 0
-      vertex -0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.39466 -0.552186 0
-      vertex -0.464888 -0.184062 0
-      vertex -1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.318711 0.385256 0
-      vertex -0.956136 1.15577 0
-      vertex -0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.464888 -0.184062 0
-      vertex -1.39466 -0.552186 0
-      vertex -0.484291 -0.124345 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.364484 0.342273 0
-      vertex -1.09345 1.02682 0
-      vertex -0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.45287 -0.373034 0
-      vertex -0.484291 -0.124345 0
-      vertex -1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.404508 0.293892 0
-      vertex -1.21352 0.881678 0
-      vertex -1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.484291 -0.124345 0
-      vertex -1.45287 -0.373034 0
-      vertex -0.496057 -0.0626659 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.438153 0.240876 0
-      vertex -1.31446 0.722631 0
-      vertex -1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.48817 -0.188 0
-      vertex -0.496057 -0.0626659 0
-      vertex -1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.464888 0.184062 0
-      vertex -1.39466 0.552186 0
-      vertex -1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.496057 -0.0626659 0
-      vertex -1.48817 -0.188 0
-      vertex -0.5 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.484291 0.124345 0
-      vertex -1.45287 0.373034 0
-      vertex -1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.5 0 0
-      vertex -0.5 0 0
-      vertex -1.48817 -0.188 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.496057 0.0626659 0
-      vertex -1.48817 0.188 0
-      vertex -1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.5 0 0
-      vertex -1.5 0 0
-      vertex -1.48817 0.188 0
-    endloop
-  endfacet
-  facet normal -0.125337 -0.992114 0
-    outer loop
-      vertex -0.281072 -1.47343 0
-      vertex -0.0941849 -1.49704 10
-      vertex -0.281072 -1.47343 10
-    endloop
-  endfacet
-  facet normal -0.125337 -0.992114 -0
-    outer loop
-      vertex -0.0941849 -1.49704 10
-      vertex -0.281072 -1.47343 0
-      vertex -0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal -0.904838 0.425756 0
-    outer loop
-      vertex -1.39466 0.552186 0
-      vertex -1.31446 0.722631 10
-      vertex -1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal -0.904838 0.425756 0
-    outer loop
-      vertex -1.31446 0.722631 10
-      vertex -1.39466 0.552186 0
-      vertex -1.39466 0.552186 10
-    endloop
-  endfacet
-  facet normal -0.770518 -0.637418 0
-    outer loop
-      vertex -1.09345 -1.02682 0
-      vertex -1.21352 -0.881678 10
-      vertex -1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal -0.770518 -0.637418 0
-    outer loop
-      vertex -1.21352 -0.881678 10
-      vertex -1.09345 -1.02682 0
-      vertex -1.09345 -1.02682 10
-    endloop
-  endfacet
-  facet normal -0.125337 0.992114 0
-    outer loop
-      vertex -0.0941849 1.49704 0
-      vertex -0.281072 1.47343 10
-      vertex -0.0941849 1.49704 10
-    endloop
-  endfacet
-  facet normal -0.125337 0.992114 0
-    outer loop
-      vertex -0.281072 1.47343 10
-      vertex -0.0941849 1.49704 0
-      vertex -0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0.684557 -0.728959 0
-    outer loop
-      vertex 0.956136 -1.15577 0
-      vertex 1.09345 -1.02682 10
-      vertex 0.956136 -1.15577 10
-    endloop
-  endfacet
-  facet normal 0.684557 -0.728959 0
-    outer loop
-      vertex 1.09345 -1.02682 10
-      vertex 0.956136 -1.15577 0
-      vertex 1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal -0.904838 -0.425756 0
-    outer loop
-      vertex -1.31446 -0.722631 0
-      vertex -1.39466 -0.552186 10
-      vertex -1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal -0.904838 -0.425756 0
-    outer loop
-      vertex -1.39466 -0.552186 10
-      vertex -1.31446 -0.722631 0
-      vertex -1.31446 -0.722631 10
-    endloop
-  endfacet
-  facet normal -0.368106 -0.929784 0
-    outer loop
-      vertex -0.638668 -1.35724 0
-      vertex -0.463525 -1.42658 10
-      vertex -0.638668 -1.35724 10
-    endloop
-  endfacet
-  facet normal -0.368106 -0.929784 -0
-    outer loop
-      vertex -0.463525 -1.42658 10
-      vertex -0.638668 -1.35724 0
-      vertex -0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal -0.587778 0.809022 0
-    outer loop
-      vertex -0.80374 1.26649 0
-      vertex -0.956136 1.15577 10
-      vertex -0.80374 1.26649 10
-    endloop
-  endfacet
-  facet normal -0.587778 0.809022 0
-    outer loop
-      vertex -0.956136 1.15577 10
-      vertex -0.80374 1.26649 0
-      vertex -0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal -0.844314 0.535848 0
-    outer loop
-      vertex -1.31446 0.722631 0
-      vertex -1.21352 0.881678 10
-      vertex -1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal -0.844314 0.535848 0
-    outer loop
-      vertex -1.21352 0.881678 10
-      vertex -1.31446 0.722631 0
-      vertex -1.31446 0.722631 10
-    endloop
-  endfacet
-  facet normal 0.844314 -0.535848 0
-    outer loop
-      vertex 1.21352 -0.881678 10
-      vertex 1.31446 -0.722631 0
-      vertex 1.31446 -0.722631 10
-    endloop
-  endfacet
-  facet normal 0.844314 -0.535848 0
-    outer loop
-      vertex 1.31446 -0.722631 0
-      vertex 1.21352 -0.881678 10
-      vertex 1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.0941849 1.49704 0
-      vertex -0.0941849 1.49704 10
-      vertex 0.0941849 1.49704 10
+      vertex -0.95613575 -1.1557693 10
+      vertex -1.0934525 -1.0268202 0
+      vertex -0.95613575 -1.1557693 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.0941849 1.49704 10
-      vertex 0.0941849 1.49704 0
-      vertex -0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal 0.770518 0.637418 0
-    outer loop
-      vertex 1.21352 0.881678 10
-      vertex 1.09345 1.02682 0
-      vertex 1.09345 1.02682 10
-    endloop
-  endfacet
-  facet normal 0.770518 0.637418 0
-    outer loop
-      vertex 1.09345 1.02682 0
-      vertex 1.21352 0.881678 10
-      vertex 1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal 0.587778 -0.809022 0
-    outer loop
-      vertex 0.80374 -1.26649 0
-      vertex 0.956136 -1.15577 10
-      vertex 0.80374 -1.26649 10
-    endloop
-  endfacet
-  facet normal 0.587778 -0.809022 0
-    outer loop
-      vertex 0.956136 -1.15577 10
-      vertex 0.80374 -1.26649 0
-      vertex 0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal -0.24871 -0.968578 0
-    outer loop
-      vertex -0.463525 -1.42658 0
-      vertex -0.281072 -1.47343 10
-      vertex -0.463525 -1.42658 10
-    endloop
-  endfacet
-  facet normal -0.24871 -0.968578 -0
-    outer loop
-      vertex -0.281072 -1.47343 10
-      vertex -0.463525 -1.42658 0
-      vertex -0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.0941849 -1.49704 0
-      vertex 0.0941849 -1.49704 10
-      vertex -0.0941849 -1.49704 10
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 0.0941849 -1.49704 10
-      vertex -0.0941849 -1.49704 0
-      vertex 0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal -0.770518 0.637418 0
-    outer loop
-      vertex -1.21352 0.881678 0
-      vertex -1.09345 1.02682 10
-      vertex -1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal -0.770518 0.637418 0
-    outer loop
-      vertex -1.09345 1.02682 10
-      vertex -1.21352 0.881678 0
-      vertex -1.21352 0.881678 10
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 0
-    outer loop
-      vertex -0.80374 -1.26649 0
-      vertex -0.638668 -1.35724 10
-      vertex -0.80374 -1.26649 10
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 -0
-    outer loop
-      vertex -0.638668 -1.35724 10
-      vertex -0.80374 -1.26649 0
-      vertex -0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal -0.684557 -0.728959 0
-    outer loop
-      vertex -1.09345 -1.02682 0
-      vertex -0.956136 -1.15577 10
-      vertex -1.09345 -1.02682 10
-    endloop
-  endfacet
-  facet normal -0.684557 -0.728959 -0
-    outer loop
-      vertex -0.956136 -1.15577 10
-      vertex -1.09345 -1.02682 0
-      vertex -0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309017 0
-    outer loop
-      vertex -1.39466 -0.552186 0
-      vertex -1.45287 -0.373034 10
-      vertex -1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309017 0
-    outer loop
-      vertex -1.45287 -0.373034 10
-      vertex -1.39466 -0.552186 0
-      vertex -1.39466 -0.552186 10
-    endloop
-  endfacet
-  facet normal 0.770518 -0.637418 0
-    outer loop
-      vertex 1.09345 -1.02682 10
-      vertex 1.21352 -0.881678 0
-      vertex 1.21352 -0.881678 10
-    endloop
-  endfacet
-  facet normal 0.770518 -0.637418 0
-    outer loop
-      vertex 1.21352 -0.881678 0
-      vertex 1.09345 -1.02682 10
-      vertex 1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal -0.998026 0.0628013 0
-    outer loop
-      vertex -1.5 0 0
-      vertex -1.48817 0.188 10
-      vertex -1.48817 0.188 0
-    endloop
-  endfacet
-  facet normal -0.998026 0.0628013 0
-    outer loop
-      vertex -1.48817 0.188 10
-      vertex -1.5 0 0
-      vertex -1.5 0 10
-    endloop
-  endfacet
-  facet normal -0.982284 0.187396 0
-    outer loop
-      vertex -1.48817 0.188 0
-      vertex -1.45287 0.373034 10
-      vertex -1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal -0.982284 0.187396 0
-    outer loop
-      vertex -1.45287 0.373034 10
-      vertex -1.48817 0.188 0
-      vertex -1.48817 0.188 10
-    endloop
-  endfacet
-  facet normal -0.951058 -0.309014 0
-    outer loop
-      vertex 0.484291 0.124345 0
-      vertex 0.464888 0.184062 10
-      vertex 0.464888 0.184062 0
-    endloop
-  endfacet
-  facet normal -0.951058 -0.309014 0
-    outer loop
-      vertex 0.464888 0.184062 10
-      vertex 0.484291 0.124345 0
-      vertex 0.484291 0.124345 10
-    endloop
-  endfacet
-  facet normal -0.982287 -0.187383 0
-    outer loop
-      vertex 0.496057 0.0626659 0
-      vertex 0.484291 0.124345 10
-      vertex 0.484291 0.124345 0
-    endloop
-  endfacet
-  facet normal -0.982287 -0.187383 0
-    outer loop
-      vertex 0.484291 0.124345 10
-      vertex 0.496057 0.0626659 0
-      vertex 0.496057 0.0626659 10
-    endloop
-  endfacet
-  facet normal -0.998026 -0.0627968 0
-    outer loop
-      vertex 0.5 0 0
-      vertex 0.496057 0.0626659 10
-      vertex 0.496057 0.0626659 0
-    endloop
-  endfacet
-  facet normal -0.998026 -0.0627968 0
-    outer loop
-      vertex 0.496057 0.0626659 10
-      vertex 0.5 0 0
-      vertex 0.5 0 10
-    endloop
-  endfacet
-  facet normal -0.844328 -0.535827 0
-    outer loop
-      vertex 0.438153 0.240876 0
-      vertex 0.404508 0.293892 10
-      vertex 0.404508 0.293892 0
-    endloop
-  endfacet
-  facet normal -0.844328 -0.535827 0
-    outer loop
-      vertex 0.404508 0.293892 10
-      vertex 0.438153 0.240876 0
-      vertex 0.438153 0.240876 10
-    endloop
-  endfacet
-  facet normal 0.770515 0.637422 0
-    outer loop
-      vertex -0.364484 -0.342273 10
-      vertex -0.404508 -0.293892 0
-      vertex -0.404508 -0.293892 10
-    endloop
-  endfacet
-  facet normal 0.770515 0.637422 0
-    outer loop
-      vertex -0.404508 -0.293892 0
-      vertex -0.364484 -0.342273 10
-      vertex -0.364484 -0.342273 0
-    endloop
-  endfacet
-  facet normal 0.125338 -0.992114 0
-    outer loop
-      vertex -0.0936899 0.491143 0
-      vertex -0.031395 0.499013 10
-      vertex -0.0936899 0.491143 10
-    endloop
-  endfacet
-  facet normal 0.125338 -0.992114 0
-    outer loop
-      vertex -0.031395 0.499013 10
-      vertex -0.0936899 0.491143 0
-      vertex -0.031395 0.499013 0
-    endloop
-  endfacet
-  facet normal -0.684541 -0.728974 0
-    outer loop
-      vertex 0.318711 0.385256 0
-      vertex 0.364484 0.342273 10
-      vertex 0.318711 0.385256 10
-    endloop
-  endfacet
-  facet normal -0.684541 -0.728974 -0
-    outer loop
-      vertex 0.364484 0.342273 10
-      vertex 0.318711 0.385256 0
-      vertex 0.364484 0.342273 0
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809016 0
-    outer loop
-      vertex -0.318711 0.385256 0
-      vertex -0.267913 0.422163 10
-      vertex -0.318711 0.385256 10
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809016 0
-    outer loop
-      vertex -0.267913 0.422163 10
-      vertex -0.318711 0.385256 0
-      vertex -0.267913 0.422163 0
-    endloop
-  endfacet
-  facet normal 0.982287 -0.187383 0
-    outer loop
-      vertex -0.496057 0.0626659 10
-      vertex -0.484291 0.124345 0
-      vertex -0.484291 0.124345 10
-    endloop
-  endfacet
-  facet normal 0.982287 -0.187383 0
-    outer loop
-      vertex -0.484291 0.124345 0
-      vertex -0.496057 0.0626659 10
-      vertex -0.496057 0.0626659 0
-    endloop
-  endfacet
-  facet normal -0.684541 0.728974 0
-    outer loop
-      vertex 0.364484 -0.342273 0
-      vertex 0.318711 -0.385256 10
-      vertex 0.364484 -0.342273 10
-    endloop
-  endfacet
-  facet normal -0.684541 0.728974 0
-    outer loop
-      vertex 0.318711 -0.385256 10
-      vertex 0.364484 -0.342273 0
-      vertex 0.318711 -0.385256 0
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 0
-    outer loop
-      vertex 0.212889 0.452413 0
-      vertex 0.267913 0.422163 10
-      vertex 0.212889 0.452413 10
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 -0
-    outer loop
-      vertex 0.267913 0.422163 10
-      vertex 0.212889 0.452413 0
-      vertex 0.267913 0.422163 0
-    endloop
-  endfacet
-  facet normal -0.248683 0.968585 0
-    outer loop
-      vertex 0.154508 -0.475528 0
-      vertex 0.0936899 -0.491143 10
-      vertex 0.154508 -0.475528 10
-    endloop
-  endfacet
-  facet normal -0.248683 0.968585 0
-    outer loop
-      vertex 0.0936899 -0.491143 10
-      vertex 0.154508 -0.475528 0
-      vertex 0.0936899 -0.491143 0
-    endloop
-  endfacet
-  facet normal 0.951058 -0.309014 0
-    outer loop
-      vertex -0.484291 0.124345 10
-      vertex -0.464888 0.184062 0
-      vertex -0.464888 0.184062 10
-    endloop
-  endfacet
-  facet normal 0.951058 -0.309014 0
-    outer loop
-      vertex -0.464888 0.184062 0
-      vertex -0.484291 0.124345 10
-      vertex -0.484291 0.124345 0
-    endloop
-  endfacet
-  facet normal -0.904825 0.425784 0
-    outer loop
-      vertex 0.438153 -0.240876 0
-      vertex 0.464888 -0.184062 10
-      vertex 0.464888 -0.184062 0
-    endloop
-  endfacet
-  facet normal -0.904825 0.425784 0
-    outer loop
-      vertex 0.464888 -0.184062 10
-      vertex 0.438153 -0.240876 0
-      vertex 0.438153 -0.240876 10
-    endloop
-  endfacet
-  facet normal 0.481757 -0.876305 0
-    outer loop
-      vertex -0.267913 0.422163 0
-      vertex -0.212889 0.452413 10
-      vertex -0.267913 0.422163 10
-    endloop
-  endfacet
-  facet normal 0.481757 -0.876305 0
-    outer loop
-      vertex -0.212889 0.452413 10
-      vertex -0.267913 0.422163 0
-      vertex -0.212889 0.452413 0
-    endloop
-  endfacet
-  facet normal 0.998026 0.0627968 0
-    outer loop
-      vertex -0.496057 -0.0626659 10
-      vertex -0.5 0 0
-      vertex -0.5 0 10
-    endloop
-  endfacet
-  facet normal 0.998026 0.0627968 0
-    outer loop
-      vertex -0.5 0 0
-      vertex -0.496057 -0.0626659 10
-      vertex -0.496057 -0.0626659 0
-    endloop
-  endfacet
-  facet normal 0.951058 0.309014 0
-    outer loop
-      vertex -0.464888 -0.184062 10
-      vertex -0.484291 -0.124345 0
-      vertex -0.484291 -0.124345 10
-    endloop
-  endfacet
-  facet normal 0.951058 0.309014 0
-    outer loop
-      vertex -0.484291 -0.124345 0
-      vertex -0.464888 -0.184062 10
-      vertex -0.464888 -0.184062 0
-    endloop
-  endfacet
-  facet normal -0.844328 0.535827 0
-    outer loop
-      vertex 0.404508 -0.293892 0
-      vertex 0.438153 -0.240876 10
-      vertex 0.438153 -0.240876 0
-    endloop
-  endfacet
-  facet normal -0.844328 0.535827 0
-    outer loop
-      vertex 0.438153 -0.240876 10
-      vertex 0.404508 -0.293892 0
-      vertex 0.404508 -0.293892 10
-    endloop
-  endfacet
-  facet normal 0.982287 0.187383 0
-    outer loop
-      vertex -0.484291 -0.124345 10
-      vertex -0.496057 -0.0626659 0
-      vertex -0.496057 -0.0626659 10
-    endloop
-  endfacet
-  facet normal 0.982287 0.187383 0
-    outer loop
-      vertex -0.496057 -0.0626659 0
-      vertex -0.484291 -0.124345 10
-      vertex -0.484291 -0.124345 0
-    endloop
-  endfacet
-  facet normal 0.904825 0.425784 0
-    outer loop
-      vertex -0.438153 -0.240876 10
-      vertex -0.464888 -0.184062 0
-      vertex -0.464888 -0.184062 10
-    endloop
-  endfacet
-  facet normal 0.904825 0.425784 0
-    outer loop
-      vertex -0.464888 -0.184062 0
-      vertex -0.438153 -0.240876 10
-      vertex -0.438153 -0.240876 0
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.031395 -0.499013 0
-      vertex -0.031395 -0.499013 10
-      vertex 0.031395 -0.499013 10
+      vertex 0.094184875 1.4970398 0
+      vertex -0.094184875 1.4970398 10
+      vertex 0.094184875 1.4970398 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.031395 -0.499013 10
-      vertex 0.031395 -0.499013 0
-      vertex -0.031395 -0.499013 0
+      vertex -0.094184875 1.4970398 10
+      vertex 0.094184875 1.4970398 0
+      vertex -0.094184875 1.4970398 0
     endloop
   endfacet
-  facet normal -0.125338 0.992114 0
+  facet normal -0.48175356 -0.8763068 0
     outer loop
-      vertex 0.0936899 -0.491143 0
-      vertex 0.031395 -0.499013 10
-      vertex 0.0936899 -0.491143 10
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.80373955 -1.2664909 10
     endloop
   endfacet
-  facet normal -0.125338 0.992114 0
+  facet normal -0.48175356 -0.8763068 0
     outer loop
-      vertex 0.031395 -0.499013 10
-      vertex 0.0936899 -0.491143 0
-      vertex 0.031395 -0.499013 0
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.63866806 -1.3572397 0
     endloop
   endfacet
-  facet normal 0.998026 -0.0627968 0
+  facet normal 0.12533255 -0.9921148 0
     outer loop
-      vertex -0.5 0 10
-      vertex -0.496057 0.0626659 0
-      vertex -0.496057 0.0626659 10
+      vertex 0.094184875 -1.4970398 0
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.094184875 -1.4970398 10
     endloop
   endfacet
-  facet normal 0.998026 -0.0627968 0
+  facet normal 0.12533255 -0.9921148 0
     outer loop
-      vertex -0.496057 0.0626659 0
-      vertex -0.5 0 10
-      vertex -0.5 0 0
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.094184875 -1.4970398 0
+      vertex 0.28107166 -1.4734306 0
     endloop
   endfacet
-  facet normal -0.904825 -0.425784 0
+  facet normal -0.8443265 -0.53582907 0
     outer loop
-      vertex 0.464888 0.184062 0
-      vertex 0.438153 0.240876 10
-      vertex 0.438153 0.240876 0
+      vertex -1.2135248 -0.8816776 0
+      vertex -1.3144598 -0.7226305 10
+      vertex -1.3144598 -0.7226305 0
     endloop
   endfacet
-  facet normal -0.904825 -0.425784 0
+  facet normal -0.8443265 -0.53582907 0
     outer loop
-      vertex 0.438153 0.240876 10
-      vertex 0.464888 0.184062 0
-      vertex 0.464888 0.184062 10
+      vertex -1.3144598 -0.7226305 10
+      vertex -1.2135248 -0.8816776 0
+      vertex -1.2135248 -0.8816776 10
     endloop
   endfacet
-  facet normal 0.587786 0.809016 -0
+  facet normal 0.90482926 -0.4257746 0
     outer loop
-      vertex -0.267913 -0.422163 0
-      vertex -0.318711 -0.385256 10
-      vertex -0.267913 -0.422163 10
+      vertex 1.3144598 -0.7226305 10
+      vertex 1.3946638 -0.552186 0
+      vertex 1.3946638 -0.552186 10
     endloop
   endfacet
-  facet normal 0.587786 0.809016 0
+  facet normal 0.90482926 -0.4257746 0
     outer loop
-      vertex -0.318711 -0.385256 10
-      vertex -0.267913 -0.422163 0
-      vertex -0.318711 -0.385256 0
+      vertex 1.3946638 -0.552186 0
+      vertex 1.3144598 -0.7226305 10
+      vertex 1.3144598 -0.7226305 0
     endloop
   endfacet
-  facet normal -0.587786 -0.809016 0
+  facet normal 0.99802655 -0.06279307 0
     outer loop
-      vertex 0.267913 0.422163 0
-      vertex 0.318711 0.385256 10
-      vertex 0.267913 0.422163 10
+      vertex 1.4881716 -0.18799973 10
+      vertex 1.5 0 0
+      vertex 1.5 0 10
     endloop
   endfacet
-  facet normal -0.587786 -0.809016 -0
+  facet normal 0.99802655 -0.06279307 0
     outer loop
-      vertex 0.318711 0.385256 10
-      vertex 0.267913 0.422163 0
-      vertex 0.318711 0.385256 0
-    endloop
-  endfacet
-  facet normal -0.481757 0.876305 0
-    outer loop
-      vertex 0.267913 -0.422163 0
-      vertex 0.212889 -0.452413 10
-      vertex 0.267913 -0.422163 10
-    endloop
-  endfacet
-  facet normal -0.481757 0.876305 0
-    outer loop
-      vertex 0.212889 -0.452413 10
-      vertex 0.267913 -0.422163 0
-      vertex 0.212889 -0.452413 0
-    endloop
-  endfacet
-  facet normal 0.368129 -0.929775 0
-    outer loop
-      vertex -0.212889 0.452413 0
-      vertex -0.154508 0.475528 10
-      vertex -0.212889 0.452413 10
-    endloop
-  endfacet
-  facet normal 0.368129 -0.929775 0
-    outer loop
-      vertex -0.154508 0.475528 10
-      vertex -0.212889 0.452413 0
-      vertex -0.154508 0.475528 0
-    endloop
-  endfacet
-  facet normal 0.684541 -0.728974 0
-    outer loop
-      vertex -0.364484 0.342273 0
-      vertex -0.318711 0.385256 10
-      vertex -0.364484 0.342273 10
-    endloop
-  endfacet
-  facet normal 0.684541 -0.728974 0
-    outer loop
-      vertex -0.318711 0.385256 10
-      vertex -0.364484 0.342273 0
-      vertex -0.318711 0.385256 0
-    endloop
-  endfacet
-  facet normal -0.368129 -0.929775 0
-    outer loop
-      vertex 0.154508 0.475528 0
-      vertex 0.212889 0.452413 10
-      vertex 0.154508 0.475528 10
-    endloop
-  endfacet
-  facet normal -0.368129 -0.929775 -0
-    outer loop
-      vertex 0.212889 0.452413 10
-      vertex 0.154508 0.475528 0
-      vertex 0.212889 0.452413 0
-    endloop
-  endfacet
-  facet normal -0.125338 -0.992114 0
-    outer loop
-      vertex 0.031395 0.499013 0
-      vertex 0.0936899 0.491143 10
-      vertex 0.031395 0.499013 10
-    endloop
-  endfacet
-  facet normal -0.125338 -0.992114 -0
-    outer loop
-      vertex 0.0936899 0.491143 10
-      vertex 0.031395 0.499013 0
-      vertex 0.0936899 0.491143 0
+      vertex 1.5 0 0
+      vertex 1.4881716 -0.18799973 10
+      vertex 1.4881716 -0.18799973 0
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -0.031395 0.499013 0
-      vertex 0.031395 0.499013 10
-      vertex -0.031395 0.499013 10
+      vertex -0.094184875 -1.4970398 0
+      vertex 0.094184875 -1.4970398 10
+      vertex -0.094184875 -1.4970398 10
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 -1 0
     outer loop
-      vertex 0.031395 0.499013 10
-      vertex -0.031395 0.499013 0
-      vertex 0.031395 0.499013 0
+      vertex 0.094184875 -1.4970398 10
+      vertex -0.094184875 -1.4970398 0
+      vertex 0.094184875 -1.4970398 0
     endloop
   endfacet
-  facet normal -0.951058 0.309014 0
+  facet normal -0.12533255 0.9921148 0
     outer loop
-      vertex 0.464888 -0.184062 0
-      vertex 0.484291 -0.124345 10
-      vertex 0.484291 -0.124345 0
+      vertex -0.094184875 1.4970398 0
+      vertex -0.28107166 1.4734306 10
+      vertex -0.094184875 1.4970398 10
     endloop
   endfacet
-  facet normal -0.951058 0.309014 0
+  facet normal -0.12533255 0.9921148 0
     outer loop
-      vertex 0.484291 -0.124345 10
-      vertex 0.464888 -0.184062 0
-      vertex 0.464888 -0.184062 10
+      vertex -0.28107166 1.4734306 10
+      vertex -0.094184875 1.4970398 0
+      vertex -0.28107166 1.4734306 0
     endloop
   endfacet
-  facet normal -0.982287 0.187383 0
+  facet normal 0.48175356 0.8763068 0
     outer loop
-      vertex 0.484291 -0.124345 0
-      vertex 0.496057 -0.0626659 10
-      vertex 0.496057 -0.0626659 0
+      vertex 0.80373955 1.2664909 0
+      vertex 0.63866806 1.3572397 10
+      vertex 0.80373955 1.2664909 10
     endloop
   endfacet
-  facet normal -0.982287 0.187383 0
+  facet normal 0.48175356 0.8763068 0
     outer loop
-      vertex 0.496057 -0.0626659 10
-      vertex 0.484291 -0.124345 0
-      vertex 0.484291 -0.124345 10
+      vertex 0.63866806 1.3572397 10
+      vertex 0.80373955 1.2664909 0
+      vertex 0.63866806 1.3572397 0
     endloop
   endfacet
-  facet normal -0.998026 0.0627968 0
+  facet normal -0.12533255 -0.9921148 0
     outer loop
-      vertex 0.496057 -0.0626659 0
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.094184875 -1.4970398 10
+      vertex -0.28107166 -1.4734306 10
+    endloop
+  endfacet
+  facet normal -0.12533255 -0.9921148 0
+    outer loop
+      vertex -0.094184875 -1.4970398 10
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.094184875 -1.4970398 0
+    endloop
+  endfacet
+  facet normal 0.68454766 -0.7289681 0
+    outer loop
+      vertex 0.95613575 -1.1557693 0
+      vertex 1.0934525 -1.0268202 10
+      vertex 0.95613575 -1.1557693 10
+    endloop
+  endfacet
+  facet normal 0.68454766 -0.7289681 0
+    outer loop
+      vertex 1.0934525 -1.0268202 10
+      vertex 0.95613575 -1.1557693 0
+      vertex 1.0934525 -1.0268202 0
+    endloop
+  endfacet
+  facet normal -0.68454766 0.7289681 0
+    outer loop
+      vertex -0.95613575 1.1557693 0
+      vertex -1.0934525 1.0268202 10
+      vertex -0.95613575 1.1557693 10
+    endloop
+  endfacet
+  facet normal -0.68454766 0.7289681 0
+    outer loop
+      vertex -1.0934525 1.0268202 10
+      vertex -0.95613575 1.1557693 0
+      vertex -1.0934525 1.0268202 0
+    endloop
+  endfacet
+  facet normal 0.9822871 -0.18738197 0
+    outer loop
+      vertex 1.4528742 -0.37303448 10
+      vertex 1.4881716 -0.18799973 0
+      vertex 1.4881716 -0.18799973 10
+    endloop
+  endfacet
+  facet normal 0.9822871 -0.18738197 0
+    outer loop
+      vertex 1.4881716 -0.18799973 0
+      vertex 1.4528742 -0.37303448 10
+      vertex 1.4528742 -0.37303448 0
+    endloop
+  endfacet
+  facet normal 0.9822871 0.18738197 0
+    outer loop
+      vertex 1.4881716 0.18799973 10
+      vertex 1.4528742 0.37303448 0
+      vertex 1.4528742 0.37303448 10
+    endloop
+  endfacet
+  facet normal 0.9822871 0.18738197 0
+    outer loop
+      vertex 1.4528742 0.37303448 0
+      vertex 1.4881716 0.18799973 10
+      vertex 1.4881716 0.18799973 0
+    endloop
+  endfacet
+  facet normal 0.90482926 0.4257746 0
+    outer loop
+      vertex 1.3946638 0.552186 10
+      vertex 1.3144598 0.7226305 0
+      vertex 1.3144598 0.7226305 10
+    endloop
+  endfacet
+  facet normal 0.90482926 0.4257746 0
+    outer loop
+      vertex 1.3144598 0.7226305 0
+      vertex 1.3946638 0.552186 10
+      vertex 1.3946638 0.552186 0
+    endloop
+  endfacet
+  facet normal -0.8443265 0.53582907 0
+    outer loop
+      vertex -1.3144598 0.7226305 0
+      vertex -1.2135248 0.8816776 10
+      vertex -1.2135248 0.8816776 0
+    endloop
+  endfacet
+  facet normal -0.8443265 0.53582907 0
+    outer loop
+      vertex -1.2135248 0.8816776 10
+      vertex -1.3144598 0.7226305 0
+      vertex -1.3144598 0.7226305 10
+    endloop
+  endfacet
+  facet normal -0.90482926 -0.4257746 0
+    outer loop
+      vertex -1.3144598 -0.7226305 0
+      vertex -1.3946638 -0.552186 10
+      vertex -1.3946638 -0.552186 0
+    endloop
+  endfacet
+  facet normal -0.90482926 -0.4257746 0
+    outer loop
+      vertex -1.3946638 -0.552186 10
+      vertex -1.3144598 -0.7226305 0
+      vertex -1.3144598 -0.7226305 10
+    endloop
+  endfacet
+  facet normal -0.77051324 0.637424 0
+    outer loop
+      vertex -1.2135248 0.8816776 0
+      vertex -1.0934525 1.0268202 10
+      vertex -1.0934525 1.0268202 0
+    endloop
+  endfacet
+  facet normal -0.77051324 0.637424 0
+    outer loop
+      vertex -1.0934525 1.0268202 10
+      vertex -1.2135248 0.8816776 0
+      vertex -1.2135248 0.8816776 10
+    endloop
+  endfacet
+  facet normal -0.90482926 0.4257746 0
+    outer loop
+      vertex -1.3946638 0.552186 0
+      vertex -1.3144598 0.7226305 10
+      vertex -1.3144598 0.7226305 0
+    endloop
+  endfacet
+  facet normal -0.90482926 0.4257746 0
+    outer loop
+      vertex -1.3144598 0.7226305 10
+      vertex -1.3946638 0.552186 0
+      vertex -1.3946638 0.552186 10
+    endloop
+  endfacet
+  facet normal 0.8443265 -0.53582907 0
+    outer loop
+      vertex 1.2135248 -0.8816776 10
+      vertex 1.3144598 -0.7226305 0
+      vertex 1.3144598 -0.7226305 10
+    endloop
+  endfacet
+  facet normal 0.8443265 -0.53582907 0
+    outer loop
+      vertex 1.3144598 -0.7226305 0
+      vertex 1.2135248 -0.8816776 10
+      vertex 1.2135248 -0.8816776 0
+    endloop
+  endfacet
+  facet normal -0.99802655 0.06279307 0
+    outer loop
+      vertex -1.5 0 0
+      vertex -1.4881716 0.18799973 10
+      vertex -1.4881716 0.18799973 0
+    endloop
+  endfacet
+  facet normal -0.99802655 0.06279307 0
+    outer loop
+      vertex -1.4881716 0.18799973 10
+      vertex -1.5 0 0
+      vertex -1.5 0 10
+    endloop
+  endfacet
+  facet normal -0.99802655 -0.06279307 0
+    outer loop
+      vertex -1.4881716 -0.18799973 0
+      vertex -1.5 0 10
+      vertex -1.5 0 0
+    endloop
+  endfacet
+  facet normal -0.99802655 -0.06279307 0
+    outer loop
+      vertex -1.5 0 10
+      vertex -1.4881716 -0.18799973 0
+      vertex -1.4881716 -0.18799973 10
+    endloop
+  endfacet
+  facet normal 0.68454766 0.7289681 0
+    outer loop
+      vertex 1.0934525 1.0268202 0
+      vertex 0.95613575 1.1557693 10
+      vertex 1.0934525 1.0268202 10
+    endloop
+  endfacet
+  facet normal 0.68454766 0.7289681 0
+    outer loop
+      vertex 0.95613575 1.1557693 10
+      vertex 1.0934525 1.0268202 0
+      vertex 0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal 0.8443265 0.53582907 0
+    outer loop
+      vertex 1.3144598 0.7226305 10
+      vertex 1.2135248 0.8816776 0
+      vertex 1.2135248 0.8816776 10
+    endloop
+  endfacet
+  facet normal 0.8443265 0.53582907 0
+    outer loop
+      vertex 1.2135248 0.8816776 0
+      vertex 1.3144598 0.7226305 10
+      vertex 1.3144598 0.7226305 0
+    endloop
+  endfacet
+  facet normal 0.12533255 0.9921148 0
+    outer loop
+      vertex 0.28107166 1.4734306 0
+      vertex 0.094184875 1.4970398 10
+      vertex 0.28107166 1.4734306 10
+    endloop
+  endfacet
+  facet normal 0.12533255 0.9921148 0
+    outer loop
+      vertex 0.094184875 1.4970398 10
+      vertex 0.28107166 1.4734306 0
+      vertex 0.094184875 1.4970398 0
+    endloop
+  endfacet
+  facet normal 0.9510557 0.30901945 0
+    outer loop
+      vertex 1.4528742 0.37303448 10
+      vertex 1.3946638 0.552186 0
+      vertex 1.3946638 0.552186 10
+    endloop
+  endfacet
+  facet normal 0.9510557 0.30901945 0
+    outer loop
+      vertex 1.3946638 0.552186 0
+      vertex 1.4528742 0.37303448 10
+      vertex 1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal -0.9510557 -0.30901945 0
+    outer loop
+      vertex -1.3946638 -0.552186 0
+      vertex -1.4528742 -0.37303448 10
+      vertex -1.4528742 -0.37303448 0
+    endloop
+  endfacet
+  facet normal -0.9510557 -0.30901945 0
+    outer loop
+      vertex -1.4528742 -0.37303448 10
+      vertex -1.3946638 -0.552186 0
+      vertex -1.3946638 -0.552186 10
+    endloop
+  endfacet
+  facet normal -0.24869178 -0.9685827 0
+    outer loop
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.46352482 -1.4265842 10
+    endloop
+  endfacet
+  facet normal -0.24869178 -0.9685827 0
+    outer loop
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.28107166 -1.4734306 0
+    endloop
+  endfacet
+  facet normal 0.36812642 0.9297758 0
+    outer loop
+      vertex 0.63866806 1.3572397 0
+      vertex 0.46352482 1.4265842 10
+      vertex 0.63866806 1.3572397 10
+    endloop
+  endfacet
+  facet normal 0.36812642 0.9297758 0
+    outer loop
+      vertex 0.46352482 1.4265842 10
+      vertex 0.63866806 1.3572397 0
+      vertex 0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal 0.24869178 -0.9685827 0
+    outer loop
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.28107166 -1.4734306 10
+    endloop
+  endfacet
+  facet normal 0.24869178 -0.9685827 0
+    outer loop
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal 0.5877827 0.80901885 0
+    outer loop
+      vertex 0.95613575 1.1557693 0
+      vertex 0.80373955 1.2664909 10
+      vertex 0.95613575 1.1557693 10
+    endloop
+  endfacet
+  facet normal 0.5877827 0.80901885 0
+    outer loop
+      vertex 0.80373955 1.2664909 10
+      vertex 0.95613575 1.1557693 0
+      vertex 0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0.9510557 -0.30901945 0
+    outer loop
+      vertex 1.3946638 -0.552186 10
+      vertex 1.4528742 -0.37303448 0
+      vertex 1.4528742 -0.37303448 10
+    endloop
+  endfacet
+  facet normal 0.9510557 -0.30901945 0
+    outer loop
+      vertex 1.4528742 -0.37303448 0
+      vertex 1.3946638 -0.552186 10
+      vertex 1.3946638 -0.552186 0
+    endloop
+  endfacet
+  facet normal -0.77051324 -0.637424 0
+    outer loop
+      vertex -1.0934525 -1.0268202 0
+      vertex -1.2135248 -0.8816776 10
+      vertex -1.2135248 -0.8816776 0
+    endloop
+  endfacet
+  facet normal -0.77051324 -0.637424 0
+    outer loop
+      vertex -1.2135248 -0.8816776 10
+      vertex -1.0934525 -1.0268202 0
+      vertex -1.0934525 -1.0268202 10
+    endloop
+  endfacet
+  facet normal -0.9822871 -0.18738197 0
+    outer loop
+      vertex -1.4528742 -0.37303448 0
+      vertex -1.4881716 -0.18799973 10
+      vertex -1.4881716 -0.18799973 0
+    endloop
+  endfacet
+  facet normal -0.9822871 -0.18738197 0
+    outer loop
+      vertex -1.4881716 -0.18799973 10
+      vertex -1.4528742 -0.37303448 0
+      vertex -1.4528742 -0.37303448 10
+    endloop
+  endfacet
+  facet normal -0.9822871 0.18738197 0
+    outer loop
+      vertex -1.4881716 0.18799973 0
+      vertex -1.4528742 0.37303448 10
+      vertex -1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal -0.9822871 0.18738197 0
+    outer loop
+      vertex -1.4528742 0.37303448 10
+      vertex -1.4881716 0.18799973 0
+      vertex -1.4881716 0.18799973 10
+    endloop
+  endfacet
+  facet normal 0.77051324 -0.637424 0
+    outer loop
+      vertex 1.0934525 -1.0268202 10
+      vertex 1.2135248 -0.8816776 0
+      vertex 1.2135248 -0.8816776 10
+    endloop
+  endfacet
+  facet normal 0.77051324 -0.637424 0
+    outer loop
+      vertex 1.2135248 -0.8816776 0
+      vertex 1.0934525 -1.0268202 10
+      vertex 1.0934525 -1.0268202 0
+    endloop
+  endfacet
+  facet normal -0.36812642 -0.9297758 0
+    outer loop
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.63866806 -1.3572397 10
+    endloop
+  endfacet
+  facet normal -0.36812642 -0.9297758 0
+    outer loop
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal -0.24869178 0.9685827 0
+    outer loop
+      vertex -0.28107166 1.4734306 0
+      vertex -0.46352482 1.4265842 10
+      vertex -0.28107166 1.4734306 10
+    endloop
+  endfacet
+  facet normal -0.24869178 0.9685827 0
+    outer loop
+      vertex -0.46352482 1.4265842 10
+      vertex -0.28107166 1.4734306 0
+      vertex -0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal -0.48175356 0.8763068 0
+    outer loop
+      vertex -0.63866806 1.3572397 0
+      vertex -0.80373955 1.2664909 10
+      vertex -0.63866806 1.3572397 10
+    endloop
+  endfacet
+  facet normal -0.48175356 0.8763068 0
+    outer loop
+      vertex -0.80373955 1.2664909 10
+      vertex -0.63866806 1.3572397 0
+      vertex -0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0.5877827 -0.80901885 0
+    outer loop
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.95613575 -1.1557693 10
+      vertex 0.80373955 -1.2664909 10
+    endloop
+  endfacet
+  facet normal 0.5877827 -0.80901885 0
+    outer loop
+      vertex 0.95613575 -1.1557693 10
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.95613575 -1.1557693 0
+    endloop
+  endfacet
+  facet normal -0.9510557 0.30901945 0
+    outer loop
+      vertex -1.4528742 0.37303448 0
+      vertex -1.3946638 0.552186 10
+      vertex -1.3946638 0.552186 0
+    endloop
+  endfacet
+  facet normal -0.9510557 0.30901945 0
+    outer loop
+      vertex -1.3946638 0.552186 10
+      vertex -1.4528742 0.37303448 0
+      vertex -1.4528742 0.37303448 10
+    endloop
+  endfacet
+  facet normal -0.5877827 0.80901885 0
+    outer loop
+      vertex -0.80373955 1.2664909 0
+      vertex -0.95613575 1.1557693 10
+      vertex -0.80373955 1.2664909 10
+    endloop
+  endfacet
+  facet normal -0.5877827 0.80901885 0
+    outer loop
+      vertex -0.95613575 1.1557693 10
+      vertex -0.80373955 1.2664909 0
+      vertex -0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal -0.36812642 0.9297758 0
+    outer loop
+      vertex -0.46352482 1.4265842 0
+      vertex -0.63866806 1.3572397 10
+      vertex -0.46352482 1.4265842 10
+    endloop
+  endfacet
+  facet normal -0.36812642 0.9297758 0
+    outer loop
+      vertex -0.63866806 1.3572397 10
+      vertex -0.46352482 1.4265842 0
+      vertex -0.63866806 1.3572397 0
+    endloop
+  endfacet
+  facet normal -0.5877827 -0.80901885 0
+    outer loop
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.95613575 -1.1557693 10
+    endloop
+  endfacet
+  facet normal -0.5877827 -0.80901885 0
+    outer loop
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.80373955 -1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 0 0
+      vertex 1.5 0 0
+      vertex 1.4881716 -0.18799973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.49605656 -0.06266594 0
+      vertex 1.4881716 -0.18799973 0
+      vertex 1.4528742 -0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.5 0 0
+      vertex 0.5 0 0
+      vertex 1.4881716 0.18799973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.48429108 -0.124344826 0
+      vertex 1.4528742 -0.37303448 0
+      vertex 1.3946638 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.49605656 0.06266594 0
+      vertex 1.4881716 0.18799973 0
+      vertex 0.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46488762 -0.184062 0
+      vertex 1.3946638 -0.552186 0
+      vertex 1.3144598 -0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4881716 0.18799973 0
+      vertex 0.49605656 0.06266594 0
+      vertex 1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.43815327 -0.2408762 0
+      vertex 1.3144598 -0.7226305 0
+      vertex 1.2135248 -0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.48429108 0.124344826 0
+      vertex 1.4528742 0.37303448 0
+      vertex 0.49605656 0.06266594 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.40450764 -0.2938919 0
+      vertex 1.2135248 -0.8816776 0
+      vertex 1.0934525 -1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4528742 0.37303448 0
+      vertex 0.48429108 0.124344826 0
+      vertex 1.3946638 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.36448383 -0.34227276 0
+      vertex 1.0934525 -1.0268202 0
+      vertex 0.95613575 -1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46488762 0.184062 0
+      vertex 1.3946638 0.552186 0
+      vertex 0.48429108 0.124344826 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.31871128 -0.3852558 0
+      vertex 0.95613575 -1.1557693 0
+      vertex 0.80373955 -1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3946638 0.552186 0
+      vertex 0.46488762 0.184062 0
+      vertex 1.3144598 0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.26791286 -0.422163 0
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.63866806 -1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.43815327 0.2408762 0
+      vertex 1.3144598 0.7226305 0
+      vertex 0.46488762 0.184062 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3144598 0.7226305 0
+      vertex 0.43815327 0.2408762 0
+      vertex 1.2135248 0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4881716 -0.18799973 0
+      vertex 0.49605656 -0.06266594 0
+      vertex 0.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4528742 -0.37303448 0
+      vertex 0.48429108 -0.124344826 0
+      vertex 0.49605656 -0.06266594 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3946638 -0.552186 0
+      vertex 0.46488762 -0.184062 0
+      vertex 0.48429108 -0.124344826 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.21288872 -0.4524126 0
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3144598 -0.7226305 0
+      vertex 0.43815327 -0.2408762 0
+      vertex 0.46488762 -0.184062 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2135248 -0.8816776 0
+      vertex 0.40450764 -0.2938919 0
+      vertex 0.43815327 -0.2408762 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0934525 -1.0268202 0
+      vertex 0.36448383 -0.34227276 0
+      vertex 0.40450764 -0.2938919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.95613575 -1.1557693 0
+      vertex 0.31871128 -0.3852558 0
+      vertex 0.36448383 -0.34227276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.15450764 -0.47552776 0
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.28107166 -1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.26791286 -0.422163 0
+      vertex 0.31871128 -0.3852558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.21288872 -0.4524126 0
+      vertex 0.26791286 -0.422163 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.15450764 -0.47552776 0
+      vertex 0.21288872 -0.4524126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.09368992 -0.49114323 0
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.094184875 -1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.09368992 -0.49114323 0
+      vertex 0.15450764 -0.47552776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.094184875 -1.4970398 0
+      vertex 0.03139496 -0.49901295 0
+      vertex 0.09368992 -0.49114323 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.094184875 -1.4970398 0
+      vertex -0.03139496 -0.49901295 0
+      vertex 0.03139496 -0.49901295 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.094184875 -1.4970398 0
+      vertex -0.03139496 -0.49901295 0
+      vertex 0.094184875 -1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.03139496 -0.49901295 0
+      vertex -0.094184875 -1.4970398 0
+      vertex -0.09368992 -0.49114323 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.09368992 -0.49114323 0
+      vertex -0.094184875 -1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.09368992 -0.49114323 0
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.15450764 -0.47552776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.15450764 -0.47552776 0
+      vertex -0.28107166 -1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.15450764 -0.47552776 0
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.21288872 -0.4524126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.21288872 -0.4524126 0
+      vertex -0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.21288872 -0.4524126 0
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.26791286 -0.422163 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.26791286 -0.422163 0
+      vertex -0.63866806 -1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.26791286 -0.422163 0
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.31871128 -0.3852558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.31871128 -0.3852558 0
+      vertex -0.80373955 -1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.31871128 -0.3852558 0
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.36448383 -0.34227276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0934525 -1.0268202 0
+      vertex -0.36448383 -0.34227276 0
+      vertex -0.95613575 -1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.36448383 -0.34227276 0
+      vertex -1.0934525 -1.0268202 0
+      vertex -0.40450764 -0.2938919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2135248 -0.8816776 0
+      vertex -0.40450764 -0.2938919 0
+      vertex -1.0934525 -1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.40450764 -0.2938919 0
+      vertex -1.2135248 -0.8816776 0
+      vertex -0.43815327 -0.2408762 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.40450764 0.2938919 0
+      vertex 1.2135248 0.8816776 0
+      vertex 0.43815327 0.2408762 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2135248 0.8816776 0
+      vertex 0.40450764 0.2938919 0
+      vertex 1.0934525 1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.36448383 0.34227276 0
+      vertex 1.0934525 1.0268202 0
+      vertex 0.40450764 0.2938919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0934525 1.0268202 0
+      vertex 0.36448383 0.34227276 0
+      vertex 0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.31871128 0.3852558 0
+      vertex 0.95613575 1.1557693 0
+      vertex 0.36448383 0.34227276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.95613575 1.1557693 0
+      vertex 0.31871128 0.3852558 0
+      vertex 0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.26791286 0.422163 0
+      vertex 0.80373955 1.2664909 0
+      vertex 0.31871128 0.3852558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.80373955 1.2664909 0
+      vertex 0.26791286 0.422163 0
+      vertex 0.63866806 1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.21288872 0.4524126 0
+      vertex 0.63866806 1.3572397 0
+      vertex 0.26791286 0.422163 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.63866806 1.3572397 0
+      vertex 0.21288872 0.4524126 0
+      vertex 0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.15450764 0.47552776 0
+      vertex 0.46352482 1.4265842 0
+      vertex 0.21288872 0.4524126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46352482 1.4265842 0
+      vertex 0.15450764 0.47552776 0
+      vertex 0.28107166 1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.09368992 0.49114323 0
+      vertex 0.28107166 1.4734306 0
+      vertex 0.15450764 0.47552776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.28107166 1.4734306 0
+      vertex 0.09368992 0.49114323 0
+      vertex 0.094184875 1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.03139496 0.49901295 0
+      vertex 0.094184875 1.4970398 0
+      vertex 0.09368992 0.49114323 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.03139496 0.49901295 0
+      vertex 0.094184875 1.4970398 0
+      vertex 0.03139496 0.49901295 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.094184875 1.4970398 0
+      vertex -0.03139496 0.49901295 0
+      vertex -0.09368992 0.49114323 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.03139496 0.49901295 0
+      vertex -0.094184875 1.4970398 0
+      vertex 0.094184875 1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.28107166 1.4734306 0
+      vertex -0.09368992 0.49114323 0
+      vertex -0.15450764 0.47552776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46352482 1.4265842 0
+      vertex -0.15450764 0.47552776 0
+      vertex -0.21288872 0.4524126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.63866806 1.3572397 0
+      vertex -0.21288872 0.4524126 0
+      vertex -0.26791286 0.422163 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.09368992 0.49114323 0
+      vertex -0.28107166 1.4734306 0
+      vertex -0.094184875 1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.80373955 1.2664909 0
+      vertex -0.26791286 0.422163 0
+      vertex -0.31871128 0.3852558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.95613575 1.1557693 0
+      vertex -0.31871128 0.3852558 0
+      vertex -0.36448383 0.34227276 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0934525 1.0268202 0
+      vertex -0.36448383 0.34227276 0
+      vertex -0.40450764 0.2938919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2135248 0.8816776 0
+      vertex -0.40450764 0.2938919 0
+      vertex -0.43815327 0.2408762 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.15450764 0.47552776 0
+      vertex -0.46352482 1.4265842 0
+      vertex -0.28107166 1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3144598 0.7226305 0
+      vertex -0.43815327 0.2408762 0
+      vertex -0.46488762 0.184062 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3946638 0.552186 0
+      vertex -0.46488762 0.184062 0
+      vertex -0.48429108 0.124344826 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4528742 0.37303448 0
+      vertex -0.48429108 0.124344826 0
+      vertex -0.49605656 0.06266594 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4881716 0.18799973 0
+      vertex -0.49605656 0.06266594 0
+      vertex -0.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3144598 -0.7226305 0
+      vertex -0.43815327 -0.2408762 0
+      vertex -1.2135248 -0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.21288872 0.4524126 0
+      vertex -0.63866806 1.3572397 0
+      vertex -0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.43815327 -0.2408762 0
+      vertex -1.3144598 -0.7226305 0
+      vertex -0.46488762 -0.184062 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.26791286 0.422163 0
+      vertex -0.80373955 1.2664909 0
+      vertex -0.63866806 1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3946638 -0.552186 0
+      vertex -0.46488762 -0.184062 0
+      vertex -1.3144598 -0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.31871128 0.3852558 0
+      vertex -0.95613575 1.1557693 0
+      vertex -0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46488762 -0.184062 0
+      vertex -1.3946638 -0.552186 0
+      vertex -0.48429108 -0.124344826 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.36448383 0.34227276 0
+      vertex -1.0934525 1.0268202 0
+      vertex -0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4528742 -0.37303448 0
+      vertex -0.48429108 -0.124344826 0
+      vertex -1.3946638 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.40450764 0.2938919 0
+      vertex -1.2135248 0.8816776 0
+      vertex -1.0934525 1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.48429108 -0.124344826 0
+      vertex -1.4528742 -0.37303448 0
+      vertex -0.49605656 -0.06266594 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.43815327 0.2408762 0
+      vertex -1.3144598 0.7226305 0
+      vertex -1.2135248 0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4881716 -0.18799973 0
+      vertex -0.49605656 -0.06266594 0
+      vertex -1.4528742 -0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46488762 0.184062 0
+      vertex -1.3946638 0.552186 0
+      vertex -1.3144598 0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.49605656 -0.06266594 0
+      vertex -1.4881716 -0.18799973 0
+      vertex -0.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.48429108 0.124344826 0
+      vertex -1.4528742 0.37303448 0
+      vertex -1.3946638 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.5 0 0
+      vertex -0.5 0 0
+      vertex -1.4881716 -0.18799973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.49605656 0.06266594 0
+      vertex -1.4881716 0.18799973 0
+      vertex -1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.5 0 0
+      vertex -1.5 0 0
+      vertex -1.4881716 0.18799973 0
+    endloop
+  endfacet
+  facet normal 0.5877851 -0.8090171 0
+    outer loop
+      vertex -0.31871128 0.3852558 0
+      vertex -0.26791286 0.422163 10
+      vertex -0.31871128 0.3852558 10
+    endloop
+  endfacet
+  facet normal 0.5877851 -0.8090171 0
+    outer loop
+      vertex -0.26791286 0.422163 10
+      vertex -0.31871128 0.3852558 0
+      vertex -0.26791286 0.422163 0
+    endloop
+  endfacet
+  facet normal -0.9980259 -0.06280379 0
+    outer loop
+      vertex 0.5 0 0
+      vertex 0.49605656 0.06266594 10
+      vertex 0.49605656 0.06266594 0
+    endloop
+  endfacet
+  facet normal -0.9980259 -0.06280379 0
+    outer loop
+      vertex 0.49605656 0.06266594 10
+      vertex 0.5 0 0
+      vertex 0.5 0 10
+    endloop
+  endfacet
+  facet normal -0.8443219 -0.5358363 0
+    outer loop
+      vertex 0.43815327 0.2408762 0
+      vertex 0.40450764 0.2938919 10
+      vertex 0.40450764 0.2938919 0
+    endloop
+  endfacet
+  facet normal -0.8443219 -0.5358363 0
+    outer loop
+      vertex 0.40450764 0.2938919 10
+      vertex 0.43815327 0.2408762 0
+      vertex 0.43815327 0.2408762 10
+    endloop
+  endfacet
+  facet normal -0.3681308 -0.929774 0
+    outer loop
+      vertex 0.15450764 0.47552776 0
+      vertex 0.21288872 0.4524126 10
+      vertex 0.15450764 0.47552776 10
+    endloop
+  endfacet
+  facet normal -0.3681308 -0.929774 0
+    outer loop
+      vertex 0.21288872 0.4524126 10
+      vertex 0.15450764 0.47552776 0
+      vertex 0.21288872 0.4524126 0
+    endloop
+  endfacet
+  facet normal -0.12533382 0.9921146 0
+    outer loop
+      vertex 0.09368992 -0.49114323 0
+      vertex 0.03139496 -0.49901295 10
+      vertex 0.09368992 -0.49114323 10
+    endloop
+  endfacet
+  facet normal -0.12533382 0.9921146 0
+    outer loop
+      vertex 0.03139496 -0.49901295 10
+      vertex 0.09368992 -0.49114323 0
+      vertex 0.03139496 -0.49901295 0
+    endloop
+  endfacet
+  facet normal 0.9048294 -0.42577437 0
+    outer loop
+      vertex -0.46488762 0.184062 10
+      vertex -0.43815327 0.2408762 0
+      vertex -0.43815327 0.2408762 10
+    endloop
+  endfacet
+  facet normal 0.9048294 -0.42577437 0
+    outer loop
+      vertex -0.43815327 0.2408762 0
+      vertex -0.46488762 0.184062 10
+      vertex -0.46488762 0.184062 0
+    endloop
+  endfacet
+  facet normal 0.4817514 0.8763079 0
+    outer loop
+      vertex -0.21288872 -0.4524126 0
+      vertex -0.26791286 -0.422163 10
+      vertex -0.21288872 -0.4524126 10
+    endloop
+  endfacet
+  facet normal 0.4817514 0.8763079 0
+    outer loop
+      vertex -0.26791286 -0.422163 10
+      vertex -0.21288872 -0.4524126 0
+      vertex -0.26791286 -0.422163 0
+    endloop
+  endfacet
+  facet normal -0.9510557 0.30901945 0
+    outer loop
+      vertex 0.46488762 -0.184062 0
+      vertex 0.48429108 -0.124344826 10
+      vertex 0.48429108 -0.124344826 0
+    endloop
+  endfacet
+  facet normal -0.9510557 0.30901945 0
+    outer loop
+      vertex 0.48429108 -0.124344826 10
+      vertex 0.46488762 -0.184062 0
+      vertex 0.46488762 -0.184062 10
+    endloop
+  endfacet
+  facet normal -0.24869178 -0.9685827 0
+    outer loop
+      vertex 0.09368992 0.49114323 0
+      vertex 0.15450764 0.47552776 10
+      vertex 0.09368992 0.49114323 10
+    endloop
+  endfacet
+  facet normal -0.24869178 -0.9685827 0
+    outer loop
+      vertex 0.15450764 0.47552776 10
+      vertex 0.09368992 0.49114323 0
+      vertex 0.15450764 0.47552776 0
+    endloop
+  endfacet
+  facet normal 0.9822884 0.18737522 0
+    outer loop
+      vertex -0.48429108 -0.124344826 10
+      vertex -0.49605656 -0.06266594 0
+      vertex -0.49605656 -0.06266594 10
+    endloop
+  endfacet
+  facet normal 0.9822884 0.18737522 0
+    outer loop
+      vertex -0.49605656 -0.06266594 0
+      vertex -0.48429108 -0.124344826 10
+      vertex -0.48429108 -0.124344826 0
+    endloop
+  endfacet
+  facet normal 0.77051574 0.637421 0
+    outer loop
+      vertex -0.36448383 -0.34227276 10
+      vertex -0.40450764 -0.2938919 0
+      vertex -0.40450764 -0.2938919 10
+    endloop
+  endfacet
+  facet normal 0.77051574 0.637421 0
+    outer loop
+      vertex -0.40450764 -0.2938919 0
+      vertex -0.36448383 -0.34227276 10
+      vertex -0.36448383 -0.34227276 0
+    endloop
+  endfacet
+  facet normal -0.9822884 0.18737522 0
+    outer loop
+      vertex 0.48429108 -0.124344826 0
+      vertex 0.49605656 -0.06266594 10
+      vertex 0.49605656 -0.06266594 0
+    endloop
+  endfacet
+  facet normal -0.9822884 0.18737522 0
+    outer loop
+      vertex 0.49605656 -0.06266594 10
+      vertex 0.48429108 -0.124344826 0
+      vertex 0.48429108 -0.124344826 10
+    endloop
+  endfacet
+  facet normal 0.9510557 0.30901945 0
+    outer loop
+      vertex -0.46488762 -0.184062 10
+      vertex -0.48429108 -0.124344826 0
+      vertex -0.48429108 -0.124344826 10
+    endloop
+  endfacet
+  facet normal 0.9510557 0.30901945 0
+    outer loop
+      vertex -0.48429108 -0.124344826 0
+      vertex -0.46488762 -0.184062 10
+      vertex -0.46488762 -0.184062 0
+    endloop
+  endfacet
+  facet normal -0.68454516 0.72897047 0
+    outer loop
+      vertex 0.36448383 -0.34227276 0
+      vertex 0.31871128 -0.3852558 10
+      vertex 0.36448383 -0.34227276 10
+    endloop
+  endfacet
+  facet normal -0.68454516 0.72897047 0
+    outer loop
+      vertex 0.31871128 -0.3852558 10
+      vertex 0.36448383 -0.34227276 0
+      vertex 0.31871128 -0.3852558 0
+    endloop
+  endfacet
+  facet normal 0.4817514 -0.8763079 0
+    outer loop
+      vertex -0.26791286 0.422163 0
+      vertex -0.21288872 0.4524126 10
+      vertex -0.26791286 0.422163 10
+    endloop
+  endfacet
+  facet normal 0.4817514 -0.8763079 0
+    outer loop
+      vertex -0.21288872 0.4524126 10
+      vertex -0.26791286 0.422163 0
+      vertex -0.21288872 0.4524126 0
+    endloop
+  endfacet
+  facet normal 0.24869178 -0.9685827 0
+    outer loop
+      vertex -0.15450764 0.47552776 0
+      vertex -0.09368992 0.49114323 10
+      vertex -0.15450764 0.47552776 10
+    endloop
+  endfacet
+  facet normal 0.24869178 -0.9685827 0
+    outer loop
+      vertex -0.09368992 0.49114323 10
+      vertex -0.15450764 0.47552776 0
+      vertex -0.09368992 0.49114323 0
+    endloop
+  endfacet
+  facet normal -0.9980259 0.06280379 0
+    outer loop
+      vertex 0.49605656 -0.06266594 0
       vertex 0.5 0 10
       vertex 0.5 0 0
     endloop
   endfacet
-  facet normal -0.998026 0.0627968 0
+  facet normal -0.9980259 0.06280379 0
     outer loop
       vertex 0.5 0 10
-      vertex 0.496057 -0.0626659 0
-      vertex 0.496057 -0.0626659 10
+      vertex 0.49605656 -0.06266594 0
+      vertex 0.49605656 -0.06266594 10
     endloop
   endfacet
-  facet normal 0.125338 0.992114 -0
+  facet normal 0.9822884 -0.18737522 0
     outer loop
-      vertex -0.031395 -0.499013 0
-      vertex -0.0936899 -0.491143 10
-      vertex -0.031395 -0.499013 10
+      vertex -0.49605656 0.06266594 10
+      vertex -0.48429108 0.124344826 0
+      vertex -0.48429108 0.124344826 10
     endloop
   endfacet
-  facet normal 0.125338 0.992114 0
+  facet normal 0.9822884 -0.18737522 0
     outer loop
-      vertex -0.0936899 -0.491143 10
-      vertex -0.031395 -0.499013 0
-      vertex -0.0936899 -0.491143 0
+      vertex -0.48429108 0.124344826 0
+      vertex -0.49605656 0.06266594 10
+      vertex -0.49605656 0.06266594 0
     endloop
   endfacet
-  facet normal -0.368129 0.929775 0
+  facet normal -0.77051574 0.637421 0
     outer loop
-      vertex 0.212889 -0.452413 0
-      vertex 0.154508 -0.475528 10
-      vertex 0.212889 -0.452413 10
+      vertex 0.36448383 -0.34227276 0
+      vertex 0.40450764 -0.2938919 10
+      vertex 0.40450764 -0.2938919 0
     endloop
   endfacet
-  facet normal -0.368129 0.929775 0
+  facet normal -0.77051574 0.637421 0
     outer loop
-      vertex 0.154508 -0.475528 10
-      vertex 0.212889 -0.452413 0
-      vertex 0.154508 -0.475528 0
+      vertex 0.40450764 -0.2938919 10
+      vertex 0.36448383 -0.34227276 0
+      vertex 0.36448383 -0.34227276 10
     endloop
   endfacet
-  facet normal -0.248683 -0.968585 0
+  facet normal -0.4817514 -0.8763079 0
     outer loop
-      vertex 0.0936899 0.491143 0
-      vertex 0.154508 0.475528 10
-      vertex 0.0936899 0.491143 10
+      vertex 0.21288872 0.4524126 0
+      vertex 0.26791286 0.422163 10
+      vertex 0.21288872 0.4524126 10
     endloop
   endfacet
-  facet normal -0.248683 -0.968585 -0
+  facet normal -0.4817514 -0.8763079 0
     outer loop
-      vertex 0.154508 0.475528 10
-      vertex 0.0936899 0.491143 0
-      vertex 0.154508 0.475528 0
+      vertex 0.26791286 0.422163 10
+      vertex 0.21288872 0.4524126 0
+      vertex 0.26791286 0.422163 0
     endloop
   endfacet
-  facet normal 0.904825 -0.425784 0
+  facet normal 0.3681308 -0.929774 0
     outer loop
-      vertex -0.464888 0.184062 10
-      vertex -0.438153 0.240876 0
-      vertex -0.438153 0.240876 10
+      vertex -0.21288872 0.4524126 0
+      vertex -0.15450764 0.47552776 10
+      vertex -0.21288872 0.4524126 10
     endloop
   endfacet
-  facet normal 0.904825 -0.425784 0
+  facet normal 0.3681308 -0.929774 0
     outer loop
-      vertex -0.438153 0.240876 0
-      vertex -0.464888 0.184062 10
-      vertex -0.464888 0.184062 0
+      vertex -0.15450764 0.47552776 10
+      vertex -0.21288872 0.4524126 0
+      vertex -0.15450764 0.47552776 0
     endloop
   endfacet
-  facet normal -0.770515 -0.637422 0
+  facet normal -0.77051574 -0.637421 0
     outer loop
-      vertex 0.404508 0.293892 0
-      vertex 0.364484 0.342273 10
-      vertex 0.364484 0.342273 0
+      vertex 0.40450764 0.2938919 0
+      vertex 0.36448383 0.34227276 10
+      vertex 0.36448383 0.34227276 0
     endloop
   endfacet
-  facet normal -0.770515 -0.637422 0
+  facet normal -0.77051574 -0.637421 0
     outer loop
-      vertex 0.364484 0.342273 10
-      vertex 0.404508 0.293892 0
-      vertex 0.404508 0.293892 10
+      vertex 0.36448383 0.34227276 10
+      vertex 0.40450764 0.2938919 0
+      vertex 0.40450764 0.2938919 10
     endloop
   endfacet
-  facet normal 0.248683 -0.968585 0
+  facet normal 0.68454516 -0.72897047 0
     outer loop
-      vertex -0.154508 0.475528 0
-      vertex -0.0936899 0.491143 10
-      vertex -0.154508 0.475528 10
+      vertex -0.36448383 0.34227276 0
+      vertex -0.31871128 0.3852558 10
+      vertex -0.36448383 0.34227276 10
     endloop
   endfacet
-  facet normal 0.248683 -0.968585 0
+  facet normal 0.68454516 -0.72897047 0
     outer loop
-      vertex -0.0936899 0.491143 10
-      vertex -0.154508 0.475528 0
-      vertex -0.0936899 0.491143 0
+      vertex -0.31871128 0.3852558 10
+      vertex -0.36448383 0.34227276 0
+      vertex -0.31871128 0.3852558 0
     endloop
   endfacet
-  facet normal 0.844328 0.535827 0
+  facet normal -0.12533382 -0.9921146 0
     outer loop
-      vertex -0.404508 -0.293892 10
-      vertex -0.438153 -0.240876 0
-      vertex -0.438153 -0.240876 10
+      vertex 0.03139496 0.49901295 0
+      vertex 0.09368992 0.49114323 10
+      vertex 0.03139496 0.49901295 10
     endloop
   endfacet
-  facet normal 0.844328 0.535827 0
+  facet normal -0.12533382 -0.9921146 0
     outer loop
-      vertex -0.438153 -0.240876 0
-      vertex -0.404508 -0.293892 10
-      vertex -0.404508 -0.293892 0
+      vertex 0.09368992 0.49114323 10
+      vertex 0.03139496 0.49901295 0
+      vertex 0.09368992 0.49114323 0
     endloop
   endfacet
-  facet normal -0.770515 0.637422 0
+  facet normal -0.8443219 0.5358363 0
     outer loop
-      vertex 0.364484 -0.342273 0
-      vertex 0.404508 -0.293892 10
-      vertex 0.404508 -0.293892 0
+      vertex 0.40450764 -0.2938919 0
+      vertex 0.43815327 -0.2408762 10
+      vertex 0.43815327 -0.2408762 0
     endloop
   endfacet
-  facet normal -0.770515 0.637422 0
+  facet normal -0.8443219 0.5358363 0
     outer loop
-      vertex 0.404508 -0.293892 10
-      vertex 0.364484 -0.342273 0
-      vertex 0.364484 -0.342273 10
+      vertex 0.43815327 -0.2408762 10
+      vertex 0.40450764 -0.2938919 0
+      vertex 0.40450764 -0.2938919 10
     endloop
   endfacet
-  facet normal 0.684541 0.728974 -0
+  facet normal -0.9822884 -0.18737522 0
     outer loop
-      vertex -0.318711 -0.385256 0
-      vertex -0.364484 -0.342273 10
-      vertex -0.318711 -0.385256 10
+      vertex 0.49605656 0.06266594 0
+      vertex 0.48429108 0.124344826 10
+      vertex 0.48429108 0.124344826 0
     endloop
   endfacet
-  facet normal 0.684541 0.728974 0
+  facet normal -0.9822884 -0.18737522 0
     outer loop
-      vertex -0.364484 -0.342273 10
-      vertex -0.318711 -0.385256 0
-      vertex -0.364484 -0.342273 0
+      vertex 0.48429108 0.124344826 10
+      vertex 0.49605656 0.06266594 0
+      vertex 0.49605656 0.06266594 10
     endloop
   endfacet
-  facet normal 0.844328 -0.535827 0
+  facet normal -0.9048294 0.42577437 0
     outer loop
-      vertex -0.438153 0.240876 10
-      vertex -0.404508 0.293892 0
-      vertex -0.404508 0.293892 10
+      vertex 0.43815327 -0.2408762 0
+      vertex 0.46488762 -0.184062 10
+      vertex 0.46488762 -0.184062 0
     endloop
   endfacet
-  facet normal 0.844328 -0.535827 0
+  facet normal -0.9048294 0.42577437 0
     outer loop
-      vertex -0.404508 0.293892 0
-      vertex -0.438153 0.240876 10
-      vertex -0.438153 0.240876 0
+      vertex 0.46488762 -0.184062 10
+      vertex 0.43815327 -0.2408762 0
+      vertex 0.43815327 -0.2408762 10
     endloop
   endfacet
-  facet normal 0.248683 0.968585 -0
+  facet normal 0.9980259 -0.06280379 0
     outer loop
-      vertex -0.0936899 -0.491143 0
-      vertex -0.154508 -0.475528 10
-      vertex -0.0936899 -0.491143 10
+      vertex -0.5 0 10
+      vertex -0.49605656 0.06266594 0
+      vertex -0.49605656 0.06266594 10
     endloop
   endfacet
-  facet normal 0.248683 0.968585 0
+  facet normal 0.9980259 -0.06280379 0
     outer loop
-      vertex -0.154508 -0.475528 10
-      vertex -0.0936899 -0.491143 0
-      vertex -0.154508 -0.475528 0
+      vertex -0.49605656 0.06266594 0
+      vertex -0.5 0 10
+      vertex -0.5 0 0
     endloop
   endfacet
-  facet normal 0.481757 0.876305 -0
+  facet normal -0.9048294 -0.42577437 0
     outer loop
-      vertex -0.212889 -0.452413 0
-      vertex -0.267913 -0.422163 10
-      vertex -0.212889 -0.452413 10
+      vertex 0.46488762 0.184062 0
+      vertex 0.43815327 0.2408762 10
+      vertex 0.43815327 0.2408762 0
     endloop
   endfacet
-  facet normal 0.481757 0.876305 0
+  facet normal -0.9048294 -0.42577437 0
     outer loop
-      vertex -0.267913 -0.422163 10
-      vertex -0.212889 -0.452413 0
-      vertex -0.267913 -0.422163 0
+      vertex 0.43815327 0.2408762 10
+      vertex 0.46488762 0.184062 0
+      vertex 0.46488762 0.184062 10
     endloop
   endfacet
-  facet normal 0.368129 0.929775 -0
+  facet normal -0.9510557 -0.30901945 0
     outer loop
-      vertex -0.154508 -0.475528 0
-      vertex -0.212889 -0.452413 10
-      vertex -0.154508 -0.475528 10
+      vertex 0.48429108 0.124344826 0
+      vertex 0.46488762 0.184062 10
+      vertex 0.46488762 0.184062 0
     endloop
   endfacet
-  facet normal 0.368129 0.929775 0
+  facet normal -0.9510557 -0.30901945 0
     outer loop
-      vertex -0.212889 -0.452413 10
-      vertex -0.154508 -0.475528 0
-      vertex -0.212889 -0.452413 0
+      vertex 0.46488762 0.184062 10
+      vertex 0.48429108 0.124344826 0
+      vertex 0.48429108 0.124344826 10
     endloop
   endfacet
-  facet normal -0.587786 0.809016 0
+  facet normal 0.12533382 -0.9921146 0
     outer loop
-      vertex 0.318711 -0.385256 0
-      vertex 0.267913 -0.422163 10
-      vertex 0.318711 -0.385256 10
+      vertex -0.09368992 0.49114323 0
+      vertex -0.03139496 0.49901295 10
+      vertex -0.09368992 0.49114323 10
     endloop
   endfacet
-  facet normal -0.587786 0.809016 0
+  facet normal 0.12533382 -0.9921146 0
     outer loop
-      vertex 0.267913 -0.422163 10
-      vertex 0.318711 -0.385256 0
-      vertex 0.267913 -0.422163 0
+      vertex -0.03139496 0.49901295 10
+      vertex -0.09368992 0.49114323 0
+      vertex -0.03139496 0.49901295 0
     endloop
   endfacet
-  facet normal 0.770515 -0.637422 0
+  facet normal 0.68454516 0.72897047 0
     outer loop
-      vertex -0.404508 0.293892 10
-      vertex -0.364484 0.342273 0
-      vertex -0.364484 0.342273 10
+      vertex -0.31871128 -0.3852558 0
+      vertex -0.36448383 -0.34227276 10
+      vertex -0.31871128 -0.3852558 10
     endloop
   endfacet
-  facet normal 0.770515 -0.637422 0
+  facet normal 0.68454516 0.72897047 0
     outer loop
-      vertex -0.364484 0.342273 0
-      vertex -0.404508 0.293892 10
-      vertex -0.404508 0.293892 0
+      vertex -0.36448383 -0.34227276 10
+      vertex -0.31871128 -0.3852558 0
+      vertex -0.36448383 -0.34227276 0
+    endloop
+  endfacet
+  facet normal 0.9980259 0.06280379 0
+    outer loop
+      vertex -0.49605656 -0.06266594 10
+      vertex -0.5 0 0
+      vertex -0.5 0 10
+    endloop
+  endfacet
+  facet normal 0.9980259 0.06280379 0
+    outer loop
+      vertex -0.5 0 0
+      vertex -0.49605656 -0.06266594 10
+      vertex -0.49605656 -0.06266594 0
+    endloop
+  endfacet
+  facet normal -0.68454516 -0.72897047 0
+    outer loop
+      vertex 0.31871128 0.3852558 0
+      vertex 0.36448383 0.34227276 10
+      vertex 0.31871128 0.3852558 10
+    endloop
+  endfacet
+  facet normal -0.68454516 -0.72897047 0
+    outer loop
+      vertex 0.36448383 0.34227276 10
+      vertex 0.31871128 0.3852558 0
+      vertex 0.36448383 0.34227276 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.03139496 0.49901295 0
+      vertex 0.03139496 0.49901295 10
+      vertex -0.03139496 0.49901295 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.03139496 0.49901295 10
+      vertex -0.03139496 0.49901295 0
+      vertex 0.03139496 0.49901295 0
+    endloop
+  endfacet
+  facet normal 0.8443219 0.5358363 0
+    outer loop
+      vertex -0.40450764 -0.2938919 10
+      vertex -0.43815327 -0.2408762 0
+      vertex -0.43815327 -0.2408762 10
+    endloop
+  endfacet
+  facet normal 0.8443219 0.5358363 0
+    outer loop
+      vertex -0.43815327 -0.2408762 0
+      vertex -0.40450764 -0.2938919 10
+      vertex -0.40450764 -0.2938919 0
+    endloop
+  endfacet
+  facet normal -0.5877851 -0.8090171 0
+    outer loop
+      vertex 0.26791286 0.422163 0
+      vertex 0.31871128 0.3852558 10
+      vertex 0.26791286 0.422163 10
+    endloop
+  endfacet
+  facet normal -0.5877851 -0.8090171 0
+    outer loop
+      vertex 0.31871128 0.3852558 10
+      vertex 0.26791286 0.422163 0
+      vertex 0.31871128 0.3852558 0
+    endloop
+  endfacet
+  facet normal 0.9510557 -0.30901945 0
+    outer loop
+      vertex -0.48429108 0.124344826 10
+      vertex -0.46488762 0.184062 0
+      vertex -0.46488762 0.184062 10
+    endloop
+  endfacet
+  facet normal 0.9510557 -0.30901945 0
+    outer loop
+      vertex -0.46488762 0.184062 0
+      vertex -0.48429108 0.124344826 10
+      vertex -0.48429108 0.124344826 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.03139496 -0.49901295 0
+      vertex -0.03139496 -0.49901295 10
+      vertex 0.03139496 -0.49901295 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.03139496 -0.49901295 10
+      vertex 0.03139496 -0.49901295 0
+      vertex -0.03139496 -0.49901295 0
+    endloop
+  endfacet
+  facet normal 0.12533382 0.9921146 0
+    outer loop
+      vertex -0.03139496 -0.49901295 0
+      vertex -0.09368992 -0.49114323 10
+      vertex -0.03139496 -0.49901295 10
+    endloop
+  endfacet
+  facet normal 0.12533382 0.9921146 0
+    outer loop
+      vertex -0.09368992 -0.49114323 10
+      vertex -0.03139496 -0.49901295 0
+      vertex -0.09368992 -0.49114323 0
+    endloop
+  endfacet
+  facet normal 0.9048294 0.42577437 0
+    outer loop
+      vertex -0.43815327 -0.2408762 10
+      vertex -0.46488762 -0.184062 0
+      vertex -0.46488762 -0.184062 10
+    endloop
+  endfacet
+  facet normal 0.9048294 0.42577437 0
+    outer loop
+      vertex -0.46488762 -0.184062 0
+      vertex -0.43815327 -0.2408762 10
+      vertex -0.43815327 -0.2408762 0
+    endloop
+  endfacet
+  facet normal 0.8443219 -0.5358363 0
+    outer loop
+      vertex -0.43815327 0.2408762 10
+      vertex -0.40450764 0.2938919 0
+      vertex -0.40450764 0.2938919 10
+    endloop
+  endfacet
+  facet normal 0.8443219 -0.5358363 0
+    outer loop
+      vertex -0.40450764 0.2938919 0
+      vertex -0.43815327 0.2408762 10
+      vertex -0.43815327 0.2408762 0
+    endloop
+  endfacet
+  facet normal -0.3681308 0.929774 0
+    outer loop
+      vertex 0.21288872 -0.4524126 0
+      vertex 0.15450764 -0.47552776 10
+      vertex 0.21288872 -0.4524126 10
+    endloop
+  endfacet
+  facet normal -0.3681308 0.929774 0
+    outer loop
+      vertex 0.15450764 -0.47552776 10
+      vertex 0.21288872 -0.4524126 0
+      vertex 0.15450764 -0.47552776 0
+    endloop
+  endfacet
+  facet normal 0.5877851 0.8090171 0
+    outer loop
+      vertex -0.26791286 -0.422163 0
+      vertex -0.31871128 -0.3852558 10
+      vertex -0.26791286 -0.422163 10
+    endloop
+  endfacet
+  facet normal 0.5877851 0.8090171 0
+    outer loop
+      vertex -0.31871128 -0.3852558 10
+      vertex -0.26791286 -0.422163 0
+      vertex -0.31871128 -0.3852558 0
+    endloop
+  endfacet
+  facet normal -0.4817514 0.8763079 0
+    outer loop
+      vertex 0.26791286 -0.422163 0
+      vertex 0.21288872 -0.4524126 10
+      vertex 0.26791286 -0.422163 10
+    endloop
+  endfacet
+  facet normal -0.4817514 0.8763079 0
+    outer loop
+      vertex 0.21288872 -0.4524126 10
+      vertex 0.26791286 -0.422163 0
+      vertex 0.21288872 -0.4524126 0
+    endloop
+  endfacet
+  facet normal 0.24869178 0.9685827 0
+    outer loop
+      vertex -0.09368992 -0.49114323 0
+      vertex -0.15450764 -0.47552776 10
+      vertex -0.09368992 -0.49114323 10
+    endloop
+  endfacet
+  facet normal 0.24869178 0.9685827 0
+    outer loop
+      vertex -0.15450764 -0.47552776 10
+      vertex -0.09368992 -0.49114323 0
+      vertex -0.15450764 -0.47552776 0
+    endloop
+  endfacet
+  facet normal -0.5877851 0.8090171 0
+    outer loop
+      vertex 0.31871128 -0.3852558 0
+      vertex 0.26791286 -0.422163 10
+      vertex 0.31871128 -0.3852558 10
+    endloop
+  endfacet
+  facet normal -0.5877851 0.8090171 0
+    outer loop
+      vertex 0.26791286 -0.422163 10
+      vertex 0.31871128 -0.3852558 0
+      vertex 0.26791286 -0.422163 0
+    endloop
+  endfacet
+  facet normal -0.24869178 0.9685827 0
+    outer loop
+      vertex 0.15450764 -0.47552776 0
+      vertex 0.09368992 -0.49114323 10
+      vertex 0.15450764 -0.47552776 10
+    endloop
+  endfacet
+  facet normal -0.24869178 0.9685827 0
+    outer loop
+      vertex 0.09368992 -0.49114323 10
+      vertex 0.15450764 -0.47552776 0
+      vertex 0.09368992 -0.49114323 0
+    endloop
+  endfacet
+  facet normal 0.77051574 -0.637421 0
+    outer loop
+      vertex -0.40450764 0.2938919 10
+      vertex -0.36448383 0.34227276 0
+      vertex -0.36448383 0.34227276 10
+    endloop
+  endfacet
+  facet normal 0.77051574 -0.637421 0
+    outer loop
+      vertex -0.36448383 0.34227276 0
+      vertex -0.40450764 0.2938919 10
+      vertex -0.40450764 0.2938919 0
+    endloop
+  endfacet
+  facet normal 0.3681308 0.929774 0
+    outer loop
+      vertex -0.15450764 -0.47552776 0
+      vertex -0.21288872 -0.4524126 10
+      vertex -0.15450764 -0.47552776 10
+    endloop
+  endfacet
+  facet normal 0.3681308 0.929774 0
+    outer loop
+      vertex -0.21288872 -0.4524126 10
+      vertex -0.15450764 -0.47552776 0
+      vertex -0.21288872 -0.4524126 0
     endloop
   endfacet
 endsolid OpenSCAD_Model

--- a/test_models/testdata/hollow_cylinder/ed_wt.stl
+++ b/test_models/testdata/hollow_cylinder/ed_wt.stl
@@ -1,2802 +1,2802 @@
 solid OpenSCAD_Model
-  facet normal 0.982284 0.187396 0
+  facet normal 0.77051324 0.637424 0
     outer loop
-      vertex 1.48817 0.188 10
-      vertex 1.45287 0.373034 0
-      vertex 1.45287 0.373034 10
+      vertex 1.2135248 0.8816776 10
+      vertex 1.0934525 1.0268202 0
+      vertex 1.0934525 1.0268202 10
     endloop
   endfacet
-  facet normal 0.982284 0.187396 0
+  facet normal 0.77051324 0.637424 0
     outer loop
-      vertex 1.45287 0.373034 0
-      vertex 1.48817 0.188 10
-      vertex 1.48817 0.188 0
+      vertex 1.0934525 1.0268202 0
+      vertex 1.2135248 0.8816776 10
+      vertex 1.2135248 0.8816776 0
     endloop
   endfacet
-  facet normal 0.998026 0.0628013 0
+  facet normal 0.24869178 0.9685827 0
+    outer loop
+      vertex 0.46352482 1.4265842 0
+      vertex 0.28107166 1.4734306 10
+      vertex 0.46352482 1.4265842 10
+    endloop
+  endfacet
+  facet normal 0.24869178 0.9685827 0
+    outer loop
+      vertex 0.28107166 1.4734306 10
+      vertex 0.46352482 1.4265842 0
+      vertex 0.28107166 1.4734306 0
+    endloop
+  endfacet
+  facet normal 0.99802655 0.06279307 0
     outer loop
       vertex 1.5 0 10
-      vertex 1.48817 0.188 0
-      vertex 1.48817 0.188 10
+      vertex 1.4881716 0.18799973 0
+      vertex 1.4881716 0.18799973 10
     endloop
   endfacet
-  facet normal 0.998026 0.0628013 0
+  facet normal 0.99802655 0.06279307 0
     outer loop
-      vertex 1.48817 0.188 0
+      vertex 1.4881716 0.18799973 0
       vertex 1.5 0 10
       vertex 1.5 0 0
     endloop
   endfacet
-  facet normal 0.904838 0.425756 0
+  facet normal 0.48175356 -0.8763068 0
     outer loop
-      vertex 1.39466 0.552186 10
-      vertex 1.31446 0.722631 0
-      vertex 1.31446 0.722631 10
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.63866806 -1.3572397 10
     endloop
   endfacet
-  facet normal 0.904838 0.425756 0
+  facet normal 0.48175356 -0.8763068 0
     outer loop
-      vertex 1.31446 0.722631 0
-      vertex 1.39466 0.552186 10
-      vertex 1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal 0.684557 0.728959 -0
-    outer loop
-      vertex 1.09345 1.02682 0
-      vertex 0.956136 1.15577 10
-      vertex 1.09345 1.02682 10
-    endloop
-  endfacet
-  facet normal 0.684557 0.728959 0
-    outer loop
-      vertex 0.956136 1.15577 10
-      vertex 1.09345 1.02682 0
-      vertex 0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal 0.24871 0.968578 -0
-    outer loop
-      vertex 0.463525 1.42658 0
-      vertex 0.281072 1.47343 10
-      vertex 0.463525 1.42658 10
-    endloop
-  endfacet
-  facet normal 0.24871 0.968578 0
-    outer loop
-      vertex 0.281072 1.47343 10
-      vertex 0.463525 1.42658 0
-      vertex 0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0.998026 -0.0628013 0
-    outer loop
-      vertex 1.48817 -0.188 10
-      vertex 1.5 0 0
-      vertex 1.5 0 10
-    endloop
-  endfacet
-  facet normal 0.998026 -0.0628013 0
-    outer loop
-      vertex 1.5 0 0
-      vertex 1.48817 -0.188 10
-      vertex 1.48817 -0.188 0
-    endloop
-  endfacet
-  facet normal 0.904838 -0.425756 0
-    outer loop
-      vertex 1.31446 -0.722631 10
-      vertex 1.39466 -0.552186 0
-      vertex 1.39466 -0.552186 10
-    endloop
-  endfacet
-  facet normal 0.904838 -0.425756 0
-    outer loop
-      vertex 1.39466 -0.552186 0
-      vertex 1.31446 -0.722631 10
-      vertex 1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal -0.587778 -0.809022 0
-    outer loop
-      vertex -0.956136 -1.15577 0
-      vertex -0.80374 -1.26649 10
-      vertex -0.956136 -1.15577 10
-    endloop
-  endfacet
-  facet normal -0.587778 -0.809022 -0
-    outer loop
-      vertex -0.80374 -1.26649 10
-      vertex -0.956136 -1.15577 0
-      vertex -0.80374 -1.26649 0
-    endloop
-  endfacet
-  facet normal 0.368106 -0.929784 0
-    outer loop
-      vertex 0.463525 -1.42658 0
-      vertex 0.638668 -1.35724 10
-      vertex 0.463525 -1.42658 10
-    endloop
-  endfacet
-  facet normal 0.368106 -0.929784 0
-    outer loop
-      vertex 0.638668 -1.35724 10
-      vertex 0.463525 -1.42658 0
-      vertex 0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal -0.844314 -0.535848 0
-    outer loop
-      vertex -1.21352 -0.881678 0
-      vertex -1.31446 -0.722631 10
-      vertex -1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal -0.844314 -0.535848 0
-    outer loop
-      vertex -1.31446 -0.722631 10
-      vertex -1.21352 -0.881678 0
-      vertex -1.21352 -0.881678 10
-    endloop
-  endfacet
-  facet normal 0.368106 0.929784 -0
-    outer loop
-      vertex 0.638668 1.35724 0
-      vertex 0.463525 1.42658 10
-      vertex 0.638668 1.35724 10
-    endloop
-  endfacet
-  facet normal 0.368106 0.929784 0
-    outer loop
-      vertex 0.463525 1.42658 10
-      vertex 0.638668 1.35724 0
-      vertex 0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal -0.481757 0.876305 0
-    outer loop
-      vertex -0.638668 1.35724 0
-      vertex -0.80374 1.26649 10
-      vertex -0.638668 1.35724 10
-    endloop
-  endfacet
-  facet normal -0.481757 0.876305 0
-    outer loop
-      vertex -0.80374 1.26649 10
-      vertex -0.638668 1.35724 0
-      vertex -0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 1.45287 0.373034 10
-      vertex 1.39466 0.552186 0
-      vertex 1.39466 0.552186 10
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 1.39466 0.552186 0
-      vertex 1.45287 0.373034 10
-      vertex 1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal 0.982284 -0.187396 0
-    outer loop
-      vertex 1.45287 -0.373034 10
-      vertex 1.48817 -0.188 0
-      vertex 1.48817 -0.188 10
-    endloop
-  endfacet
-  facet normal 0.982284 -0.187396 0
-    outer loop
-      vertex 1.48817 -0.188 0
-      vertex 1.45287 -0.373034 10
-      vertex 1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal 0.481757 0.876305 -0
-    outer loop
-      vertex 0.80374 1.26649 0
-      vertex 0.638668 1.35724 10
-      vertex 0.80374 1.26649 10
-    endloop
-  endfacet
-  facet normal 0.481757 0.876305 0
-    outer loop
-      vertex 0.638668 1.35724 10
-      vertex 0.80374 1.26649 0
-      vertex 0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0.125337 -0.992114 0
-    outer loop
-      vertex 0.0941849 -1.49704 0
-      vertex 0.281072 -1.47343 10
-      vertex 0.0941849 -1.49704 10
-    endloop
-  endfacet
-  facet normal 0.125337 -0.992114 0
-    outer loop
-      vertex 0.281072 -1.47343 10
-      vertex 0.0941849 -1.49704 0
-      vertex 0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -1.45287 0.373034 0
-      vertex -1.39466 0.552186 10
-      vertex -1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -1.39466 0.552186 10
-      vertex -1.45287 0.373034 0
-      vertex -1.45287 0.373034 10
-    endloop
-  endfacet
-  facet normal 0.844314 0.535848 0
-    outer loop
-      vertex 1.31446 0.722631 10
-      vertex 1.21352 0.881678 0
-      vertex 1.21352 0.881678 10
-    endloop
-  endfacet
-  facet normal 0.844314 0.535848 0
-    outer loop
-      vertex 1.21352 0.881678 0
-      vertex 1.31446 0.722631 10
-      vertex 1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex 1.39466 -0.552186 10
-      vertex 1.45287 -0.373034 0
-      vertex 1.45287 -0.373034 10
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex 1.45287 -0.373034 0
-      vertex 1.39466 -0.552186 10
-      vertex 1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal -0.684557 0.728959 0
-    outer loop
-      vertex -0.956136 1.15577 0
-      vertex -1.09345 1.02682 10
-      vertex -0.956136 1.15577 10
-    endloop
-  endfacet
-  facet normal -0.684557 0.728959 0
-    outer loop
-      vertex -1.09345 1.02682 10
-      vertex -0.956136 1.15577 0
-      vertex -1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal 0.24871 -0.968578 0
-    outer loop
-      vertex 0.281072 -1.47343 0
-      vertex 0.463525 -1.42658 10
-      vertex 0.281072 -1.47343 10
-    endloop
-  endfacet
-  facet normal 0.24871 -0.968578 0
-    outer loop
-      vertex 0.463525 -1.42658 10
-      vertex 0.281072 -1.47343 0
-      vertex 0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal -0.368106 0.929784 0
-    outer loop
-      vertex -0.463525 1.42658 0
-      vertex -0.638668 1.35724 10
-      vertex -0.463525 1.42658 10
-    endloop
-  endfacet
-  facet normal -0.368106 0.929784 0
-    outer loop
-      vertex -0.638668 1.35724 10
-      vertex -0.463525 1.42658 0
-      vertex -0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0.125337 0.992114 -0
-    outer loop
-      vertex 0.281072 1.47343 0
-      vertex 0.0941849 1.49704 10
-      vertex 0.281072 1.47343 10
-    endloop
-  endfacet
-  facet normal 0.125337 0.992114 0
-    outer loop
-      vertex 0.0941849 1.49704 10
-      vertex 0.281072 1.47343 0
-      vertex 0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal -0.24871 0.968578 0
-    outer loop
-      vertex -0.281072 1.47343 0
-      vertex -0.463525 1.42658 10
-      vertex -0.281072 1.47343 10
-    endloop
-  endfacet
-  facet normal -0.24871 0.968578 0
-    outer loop
-      vertex -0.463525 1.42658 10
-      vertex -0.281072 1.47343 0
-      vertex -0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal -0.982284 -0.187396 0
-    outer loop
-      vertex -1.45287 -0.373034 0
-      vertex -1.48817 -0.188 10
-      vertex -1.48817 -0.188 0
-    endloop
-  endfacet
-  facet normal -0.982284 -0.187396 0
-    outer loop
-      vertex -1.48817 -0.188 10
-      vertex -1.45287 -0.373034 0
-      vertex -1.45287 -0.373034 10
-    endloop
-  endfacet
-  facet normal 0.587778 0.809022 -0
-    outer loop
-      vertex 0.956136 1.15577 0
-      vertex 0.80374 1.26649 10
-      vertex 0.956136 1.15577 10
-    endloop
-  endfacet
-  facet normal 0.587778 0.809022 0
-    outer loop
-      vertex 0.80374 1.26649 10
-      vertex 0.956136 1.15577 0
-      vertex 0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal -0.998026 -0.0628013 0
-    outer loop
-      vertex -1.48817 -0.188 0
-      vertex -1.5 0 10
-      vertex -1.5 0 0
-    endloop
-  endfacet
-  facet normal -0.998026 -0.0628013 0
-    outer loop
-      vertex -1.5 0 10
-      vertex -1.48817 -0.188 0
-      vertex -1.48817 -0.188 10
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.80373955 -1.2664909 0
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.3 0 10
+      vertex 1.2999992 0 10
       vertex 1.5 0 10
-      vertex 1.48817 0.188 10
+      vertex 1.4881716 0.18799973 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.28975 0.162932 10
-      vertex 1.48817 0.188 10
-      vertex 1.45287 0.373034 10
+      vertex 1.2897482 0.1629324 10
+      vertex 1.4881716 0.18799973 10
+      vertex 1.4528742 0.37303448 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex 1.5 0 10
-      vertex 1.3 0 10
-      vertex 1.48817 -0.188 10
+      vertex 1.2999992 0 10
+      vertex 1.4881716 -0.18799973 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.25916 0.323297 10
-      vertex 1.45287 0.373034 10
-      vertex 1.39466 0.552186 10
+      vertex 1.2591572 0.32329655 10
+      vertex 1.4528742 0.37303448 10
+      vertex 1.3946638 0.552186 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 1.28975 -0.162932 10
-      vertex 1.48817 -0.188 10
-      vertex 1.3 0 10
+      vertex 1.2897482 -0.1629324 10
+      vertex 1.4881716 -0.18799973 10
+      vertex 1.2999992 0 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.20871 0.478561 10
-      vertex 1.39466 0.552186 10
-      vertex 1.31446 0.722631 10
+      vertex 1.2087088 0.4785614 10
+      vertex 1.3946638 0.552186 10
+      vertex 1.3144598 0.7226305 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.48817 -0.188 10
-      vertex 1.28975 -0.162932 10
-      vertex 1.45287 -0.373034 10
+      vertex 1.4881716 -0.18799973 10
+      vertex 1.2897482 -0.1629324 10
+      vertex 1.4528742 -0.37303448 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 1.25916 -0.323297 10
-      vertex 1.45287 -0.373034 10
-      vertex 1.28975 -0.162932 10
+      vertex 1.2591572 -0.32329655 10
+      vertex 1.4528742 -0.37303448 10
+      vertex 1.2897482 -0.1629324 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.48817 0.188 10
-      vertex 1.28975 0.162932 10
-      vertex 1.3 0 10
+      vertex 1.4881716 0.18799973 10
+      vertex 1.2897482 0.1629324 10
+      vertex 1.2999992 0 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.45287 0.373034 10
-      vertex 1.25916 0.323297 10
-      vertex 1.28975 0.162932 10
+      vertex 1.4528742 0.37303448 10
+      vertex 1.2591572 0.32329655 10
+      vertex 1.2897482 0.1629324 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.1392 0.626279 10
-      vertex 1.31446 0.722631 10
-      vertex 1.21352 0.881678 10
+      vertex 1.1391983 0.6262789 10
+      vertex 1.3144598 0.7226305 10
+      vertex 1.2135248 0.8816776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.39466 0.552186 10
-      vertex 1.20871 0.478561 10
-      vertex 1.25916 0.323297 10
+      vertex 1.3946638 0.552186 10
+      vertex 1.2087088 0.4785614 10
+      vertex 1.2591572 0.32329655 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.31446 0.722631 10
-      vertex 1.1392 0.626279 10
-      vertex 1.20871 0.478561 10
+      vertex 1.3144598 0.7226305 10
+      vertex 1.1391983 0.6262789 10
+      vertex 1.2087088 0.4785614 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.05172 0.76412 10
-      vertex 1.21352 0.881678 10
-      vertex 1.09345 1.02682 10
+      vertex 1.0517216 0.7641201 10
+      vertex 1.2135248 0.8816776 10
+      vertex 1.0934525 1.0268202 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.21352 0.881678 10
-      vertex 1.05172 0.76412 10
-      vertex 1.1392 0.626279 10
+      vertex 1.2135248 0.8816776 10
+      vertex 1.0517216 0.7641201 10
+      vertex 1.1391983 0.6262789 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.947659 0.889911 10
-      vertex 1.09345 1.02682 10
-      vertex 0.956136 1.15577 10
+      vertex 0.94765854 0.8899107 10
+      vertex 1.0934525 1.0268202 10
+      vertex 0.95613575 1.1557693 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.09345 1.02682 10
-      vertex 0.947659 0.889911 10
-      vertex 1.05172 0.76412 10
+      vertex 1.0934525 1.0268202 10
+      vertex 0.94765854 0.8899107 10
+      vertex 1.0517216 0.7641201 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.956136 1.15577 10
-      vertex 0.82865 1.00167 10
-      vertex 0.947659 0.889911 10
+      vertex 0.95613575 1.1557693 10
+      vertex 0.8286505 1.001667 10
+      vertex 0.94765854 0.8899107 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.80374 1.26649 10
-      vertex 0.82865 1.00167 10
-      vertex 0.956136 1.15577 10
+      vertex 0.80373955 1.2664909 10
+      vertex 0.8286505 1.001667 10
+      vertex 0.95613575 1.1557693 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.80374 1.26649 10
-      vertex 0.696574 1.09763 10
-      vertex 0.82865 1.00167 10
+      vertex 0.80373955 1.2664909 10
+      vertex 0.6965742 1.0976257 10
+      vertex 0.8286505 1.001667 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.638668 1.35724 10
-      vertex 0.696574 1.09763 10
-      vertex 0.80374 1.26649 10
+      vertex 0.63866806 1.3572397 10
+      vertex 0.6965742 1.0976257 10
+      vertex 0.80373955 1.2664909 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.638668 1.35724 10
-      vertex 0.553513 1.17627 10
-      vertex 0.696574 1.09763 10
+      vertex 0.63866806 1.3572397 10
+      vertex 0.5535126 1.1762743 10
+      vertex 0.6965742 1.0976257 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.463525 1.42658 10
-      vertex 0.553513 1.17627 10
-      vertex 0.638668 1.35724 10
+      vertex 0.46352482 1.4265842 10
+      vertex 0.5535126 1.1762743 10
+      vertex 0.63866806 1.3572397 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.463525 1.42658 10
-      vertex 0.401722 1.23637 10
-      vertex 0.553513 1.17627 10
+      vertex 0.46352482 1.4265842 10
+      vertex 0.40172195 1.236373 10
+      vertex 0.5535126 1.1762743 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.281072 1.47343 10
-      vertex 0.401722 1.23637 10
-      vertex 0.463525 1.42658 10
+      vertex 0.28107166 1.4734306 10
+      vertex 0.40172195 1.236373 10
+      vertex 0.46352482 1.4265842 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.281072 1.47343 10
-      vertex 0.243595 1.27697 10
-      vertex 0.401722 1.23637 10
+      vertex 0.28107166 1.4734306 10
+      vertex 0.24359512 1.2769728 10
+      vertex 0.40172195 1.236373 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.0941849 1.49704 10
-      vertex 0.243595 1.27697 10
-      vertex 0.281072 1.47343 10
+      vertex 0.094184875 1.4970398 10
+      vertex 0.24359512 1.2769728 10
+      vertex 0.28107166 1.4734306 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.0941849 1.49704 10
-      vertex 0.0816269 1.29743 10
-      vertex 0.243595 1.27697 10
+      vertex 0.094184875 1.4970398 10
+      vertex 0.08162689 1.2974339 10
+      vertex 0.24359512 1.2769728 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.0941849 1.49704 10
-      vertex -0.0816269 1.29743 10
-      vertex 0.0816269 1.29743 10
+      vertex 0.094184875 1.4970398 10
+      vertex -0.08162689 1.2974339 10
+      vertex 0.08162689 1.2974339 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -0.0941849 1.49704 10
-      vertex -0.0816269 1.29743 10
-      vertex 0.0941849 1.49704 10
+      vertex -0.094184875 1.4970398 10
+      vertex -0.08162689 1.2974339 10
+      vertex 0.094184875 1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.0941849 1.49704 10
-      vertex -0.243595 1.27697 10
-      vertex -0.0816269 1.29743 10
+      vertex -0.094184875 1.4970398 10
+      vertex -0.24359512 1.2769728 10
+      vertex -0.08162689 1.2974339 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -0.281072 1.47343 10
-      vertex -0.243595 1.27697 10
-      vertex -0.0941849 1.49704 10
+      vertex -0.28107166 1.4734306 10
+      vertex -0.24359512 1.2769728 10
+      vertex -0.094184875 1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.281072 1.47343 10
-      vertex -0.401722 1.23637 10
-      vertex -0.243595 1.27697 10
+      vertex -0.28107166 1.4734306 10
+      vertex -0.40172195 1.236373 10
+      vertex -0.24359512 1.2769728 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -0.463525 1.42658 10
-      vertex -0.401722 1.23637 10
-      vertex -0.281072 1.47343 10
+      vertex -0.46352482 1.4265842 10
+      vertex -0.40172195 1.236373 10
+      vertex -0.28107166 1.4734306 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.463525 1.42658 10
-      vertex -0.553513 1.17627 10
-      vertex -0.401722 1.23637 10
+      vertex -0.46352482 1.4265842 10
+      vertex -0.5535126 1.1762743 10
+      vertex -0.40172195 1.236373 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -0.638668 1.35724 10
-      vertex -0.553513 1.17627 10
-      vertex -0.463525 1.42658 10
+      vertex -0.63866806 1.3572397 10
+      vertex -0.5535126 1.1762743 10
+      vertex -0.46352482 1.4265842 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.638668 1.35724 10
-      vertex -0.696574 1.09763 10
-      vertex -0.553513 1.17627 10
+      vertex -0.63866806 1.3572397 10
+      vertex -0.6965742 1.0976257 10
+      vertex -0.5535126 1.1762743 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -0.80374 1.26649 10
-      vertex -0.696574 1.09763 10
-      vertex -0.638668 1.35724 10
+      vertex -0.80373955 1.2664909 10
+      vertex -0.6965742 1.0976257 10
+      vertex -0.63866806 1.3572397 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.80374 1.26649 10
-      vertex -0.82865 1.00167 10
-      vertex -0.696574 1.09763 10
+      vertex -0.80373955 1.2664909 10
+      vertex -0.8286505 1.001667 10
+      vertex -0.6965742 1.0976257 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -0.956136 1.15577 10
-      vertex -0.82865 1.00167 10
-      vertex -0.80374 1.26649 10
+      vertex -0.95613575 1.1557693 10
+      vertex -0.8286505 1.001667 10
+      vertex -0.80373955 1.2664909 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.82865 1.00167 10
-      vertex -0.956136 1.15577 10
-      vertex -0.947659 0.889911 10
+      vertex -0.8286505 1.001667 10
+      vertex -0.95613575 1.1557693 10
+      vertex -0.94765854 0.8899107 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.09345 1.02682 10
-      vertex -0.947659 0.889911 10
-      vertex -0.956136 1.15577 10
+      vertex -1.0934525 1.0268202 10
+      vertex -0.94765854 0.8899107 10
+      vertex -0.95613575 1.1557693 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.947659 0.889911 10
-      vertex -1.09345 1.02682 10
-      vertex -1.05172 0.76412 10
+      vertex -0.94765854 0.8899107 10
+      vertex -1.0934525 1.0268202 10
+      vertex -1.0517216 0.7641201 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.21352 0.881678 10
-      vertex -1.05172 0.76412 10
-      vertex -1.09345 1.02682 10
+      vertex -1.2135248 0.8816776 10
+      vertex -1.0517216 0.7641201 10
+      vertex -1.0934525 1.0268202 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.05172 0.76412 10
-      vertex -1.21352 0.881678 10
-      vertex -1.1392 0.626279 10
+      vertex -1.0517216 0.7641201 10
+      vertex -1.2135248 0.8816776 10
+      vertex -1.1391983 0.6262789 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.31446 0.722631 10
-      vertex -1.1392 0.626279 10
-      vertex -1.21352 0.881678 10
+      vertex -1.3144598 0.7226305 10
+      vertex -1.1391983 0.6262789 10
+      vertex -1.2135248 0.8816776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.1392 0.626279 10
-      vertex -1.31446 0.722631 10
-      vertex -1.20871 0.478561 10
+      vertex -1.1391983 0.6262789 10
+      vertex -1.3144598 0.7226305 10
+      vertex -1.2087088 0.4785614 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.39466 0.552186 10
-      vertex -1.20871 0.478561 10
-      vertex -1.31446 0.722631 10
+      vertex -1.3946638 0.552186 10
+      vertex -1.2087088 0.4785614 10
+      vertex -1.3144598 0.7226305 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.45287 0.373034 10
-      vertex -1.25916 0.323297 10
-      vertex -1.39466 0.552186 10
+      vertex -1.4528742 0.37303448 10
+      vertex -1.2591572 0.32329655 10
+      vertex -1.3946638 0.552186 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.20871 0.478561 10
-      vertex -1.39466 0.552186 10
-      vertex -1.25916 0.323297 10
+      vertex -1.2087088 0.4785614 10
+      vertex -1.3946638 0.552186 10
+      vertex -1.2591572 0.32329655 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.45287 -0.373034 10
-      vertex 1.25916 -0.323297 10
-      vertex 1.39466 -0.552186 10
+      vertex 1.4528742 -0.37303448 10
+      vertex 1.2591572 -0.32329655 10
+      vertex 1.3946638 -0.552186 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 1.20871 -0.478561 10
-      vertex 1.39466 -0.552186 10
-      vertex 1.25916 -0.323297 10
+      vertex 1.2087088 -0.4785614 10
+      vertex 1.3946638 -0.552186 10
+      vertex 1.2591572 -0.32329655 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.39466 -0.552186 10
-      vertex 1.20871 -0.478561 10
-      vertex 1.31446 -0.722631 10
+      vertex 1.3946638 -0.552186 10
+      vertex 1.2087088 -0.4785614 10
+      vertex 1.3144598 -0.7226305 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 1.1392 -0.626279 10
-      vertex 1.31446 -0.722631 10
-      vertex 1.20871 -0.478561 10
+      vertex 1.1391983 -0.6262789 10
+      vertex 1.3144598 -0.7226305 10
+      vertex 1.2087088 -0.4785614 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.31446 -0.722631 10
-      vertex 1.1392 -0.626279 10
-      vertex 1.21352 -0.881678 10
+      vertex 1.3144598 -0.7226305 10
+      vertex 1.1391983 -0.6262789 10
+      vertex 1.2135248 -0.8816776 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 1.05172 -0.76412 10
-      vertex 1.21352 -0.881678 10
-      vertex 1.1392 -0.626279 10
+      vertex 1.0517216 -0.7641201 10
+      vertex 1.2135248 -0.8816776 10
+      vertex 1.1391983 -0.6262789 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.21352 -0.881678 10
-      vertex 1.05172 -0.76412 10
-      vertex 1.09345 -1.02682 10
+      vertex 1.2135248 -0.8816776 10
+      vertex 1.0517216 -0.7641201 10
+      vertex 1.0934525 -1.0268202 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.947659 -0.889911 10
-      vertex 1.09345 -1.02682 10
-      vertex 1.05172 -0.76412 10
+      vertex 0.94765854 -0.8899107 10
+      vertex 1.0934525 -1.0268202 10
+      vertex 1.0517216 -0.7641201 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.09345 -1.02682 10
-      vertex 0.947659 -0.889911 10
-      vertex 0.956136 -1.15577 10
+      vertex 1.0934525 -1.0268202 10
+      vertex 0.94765854 -0.8899107 10
+      vertex 0.95613575 -1.1557693 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.82865 -1.00167 10
-      vertex 0.956136 -1.15577 10
-      vertex 0.947659 -0.889911 10
+      vertex 0.8286505 -1.001667 10
+      vertex 0.95613575 -1.1557693 10
+      vertex 0.94765854 -0.8899107 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.82865 -1.00167 10
-      vertex 0.80374 -1.26649 10
-      vertex 0.956136 -1.15577 10
+      vertex 0.8286505 -1.001667 10
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.95613575 -1.1557693 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.696574 -1.09763 10
-      vertex 0.80374 -1.26649 10
-      vertex 0.82865 -1.00167 10
+      vertex 0.6965742 -1.0976257 10
+      vertex 0.80373955 -1.2664909 10
+      vertex 0.8286505 -1.001667 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.696574 -1.09763 10
-      vertex 0.638668 -1.35724 10
-      vertex 0.80374 -1.26649 10
+      vertex 0.6965742 -1.0976257 10
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.80373955 -1.2664909 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.553513 -1.17627 10
-      vertex 0.638668 -1.35724 10
-      vertex 0.696574 -1.09763 10
+      vertex 0.5535126 -1.1762743 10
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.6965742 -1.0976257 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.553513 -1.17627 10
-      vertex 0.463525 -1.42658 10
-      vertex 0.638668 -1.35724 10
+      vertex 0.5535126 -1.1762743 10
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.63866806 -1.3572397 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.401722 -1.23637 10
-      vertex 0.463525 -1.42658 10
-      vertex 0.553513 -1.17627 10
+      vertex 0.40172195 -1.236373 10
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.5535126 -1.1762743 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.401722 -1.23637 10
-      vertex 0.281072 -1.47343 10
-      vertex 0.463525 -1.42658 10
+      vertex 0.40172195 -1.236373 10
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.46352482 -1.4265842 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.243595 -1.27697 10
-      vertex 0.281072 -1.47343 10
-      vertex 0.401722 -1.23637 10
+      vertex 0.24359512 -1.2769728 10
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.40172195 -1.236373 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.243595 -1.27697 10
-      vertex 0.0941849 -1.49704 10
-      vertex 0.281072 -1.47343 10
+      vertex 0.24359512 -1.2769728 10
+      vertex 0.094184875 -1.4970398 10
+      vertex 0.28107166 -1.4734306 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex 0.0816269 -1.29743 10
-      vertex 0.0941849 -1.49704 10
-      vertex 0.243595 -1.27697 10
+      vertex 0.08162689 -1.2974339 10
+      vertex 0.094184875 -1.4970398 10
+      vertex 0.24359512 -1.2769728 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -0.0816269 -1.29743 10
-      vertex 0.0941849 -1.49704 10
-      vertex 0.0816269 -1.29743 10
+      vertex -0.08162689 -1.2974339 10
+      vertex 0.094184875 -1.4970398 10
+      vertex 0.08162689 -1.2974339 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.0816269 -1.29743 10
-      vertex -0.0941849 -1.49704 10
-      vertex 0.0941849 -1.49704 10
+      vertex -0.08162689 -1.2974339 10
+      vertex -0.094184875 -1.4970398 10
+      vertex 0.094184875 -1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.243595 -1.27697 10
-      vertex -0.0941849 -1.49704 10
-      vertex -0.0816269 -1.29743 10
+      vertex -0.24359512 -1.2769728 10
+      vertex -0.094184875 -1.4970398 10
+      vertex -0.08162689 -1.2974339 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.243595 -1.27697 10
-      vertex -0.281072 -1.47343 10
-      vertex -0.0941849 -1.49704 10
+      vertex -0.24359512 -1.2769728 10
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.094184875 -1.4970398 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.401722 -1.23637 10
-      vertex -0.281072 -1.47343 10
-      vertex -0.243595 -1.27697 10
+      vertex -0.40172195 -1.236373 10
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.24359512 -1.2769728 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.401722 -1.23637 10
-      vertex -0.463525 -1.42658 10
-      vertex -0.281072 -1.47343 10
+      vertex -0.40172195 -1.236373 10
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.28107166 -1.4734306 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.553513 -1.17627 10
-      vertex -0.463525 -1.42658 10
-      vertex -0.401722 -1.23637 10
+      vertex -0.5535126 -1.1762743 10
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.40172195 -1.236373 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.553513 -1.17627 10
-      vertex -0.638668 -1.35724 10
-      vertex -0.463525 -1.42658 10
+      vertex -0.5535126 -1.1762743 10
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.46352482 -1.4265842 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.696574 -1.09763 10
-      vertex -0.638668 -1.35724 10
-      vertex -0.553513 -1.17627 10
+      vertex -0.6965742 -1.0976257 10
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.5535126 -1.1762743 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.696574 -1.09763 10
-      vertex -0.80374 -1.26649 10
-      vertex -0.638668 -1.35724 10
+      vertex -0.6965742 -1.0976257 10
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.63866806 -1.3572397 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.82865 -1.00167 10
-      vertex -0.80374 -1.26649 10
-      vertex -0.696574 -1.09763 10
+      vertex -0.8286505 -1.001667 10
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.6965742 -1.0976257 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.956136 -1.15577 10
-      vertex -0.82865 -1.00167 10
-      vertex -0.947659 -0.889911 10
+      vertex -0.95613575 -1.1557693 10
+      vertex -0.8286505 -1.001667 10
+      vertex -0.94765854 -0.8899107 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.82865 -1.00167 10
-      vertex -0.956136 -1.15577 10
-      vertex -0.80374 -1.26649 10
+      vertex -0.8286505 -1.001667 10
+      vertex -0.95613575 -1.1557693 10
+      vertex -0.80373955 -1.2664909 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.09345 -1.02682 10
-      vertex -0.947659 -0.889911 10
-      vertex -1.05172 -0.76412 10
+      vertex -1.0934525 -1.0268202 10
+      vertex -0.94765854 -0.8899107 10
+      vertex -1.0517216 -0.7641201 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.947659 -0.889911 10
-      vertex -1.09345 -1.02682 10
-      vertex -0.956136 -1.15577 10
+      vertex -0.94765854 -0.8899107 10
+      vertex -1.0934525 -1.0268202 10
+      vertex -0.95613575 -1.1557693 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.21352 -0.881678 10
-      vertex -1.05172 -0.76412 10
-      vertex -1.1392 -0.626279 10
+      vertex -1.2135248 -0.8816776 10
+      vertex -1.0517216 -0.7641201 10
+      vertex -1.1391983 -0.6262789 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.31446 -0.722631 10
-      vertex -1.1392 -0.626279 10
-      vertex -1.20871 -0.478561 10
+      vertex -1.3144598 -0.7226305 10
+      vertex -1.1391983 -0.6262789 10
+      vertex -1.2087088 -0.4785614 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.05172 -0.76412 10
-      vertex -1.21352 -0.881678 10
-      vertex -1.09345 -1.02682 10
+      vertex -1.0517216 -0.7641201 10
+      vertex -1.2135248 -0.8816776 10
+      vertex -1.0934525 -1.0268202 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.39466 -0.552186 10
-      vertex -1.20871 -0.478561 10
-      vertex -1.25916 -0.323297 10
+      vertex -1.3946638 -0.552186 10
+      vertex -1.2087088 -0.4785614 10
+      vertex -1.2591572 -0.32329655 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.45287 -0.373034 10
-      vertex -1.25916 -0.323297 10
-      vertex -1.28975 -0.162932 10
+      vertex -1.4528742 -0.37303448 10
+      vertex -1.2591572 -0.32329655 10
+      vertex -1.2897482 -0.1629324 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.1392 -0.626279 10
-      vertex -1.31446 -0.722631 10
-      vertex -1.21352 -0.881678 10
+      vertex -1.1391983 -0.6262789 10
+      vertex -1.3144598 -0.7226305 10
+      vertex -1.2135248 -0.8816776 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.48817 -0.188 10
-      vertex -1.28975 -0.162932 10
-      vertex -1.3 0 10
+      vertex -1.4881716 -0.18799973 10
+      vertex -1.2897482 -0.1629324 10
+      vertex -1.2999992 0 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.25916 0.323297 10
-      vertex -1.45287 0.373034 10
-      vertex -1.28975 0.162932 10
+      vertex -1.2591572 0.32329655 10
+      vertex -1.4528742 0.37303448 10
+      vertex -1.2897482 0.1629324 10
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
-      vertex -1.48817 0.188 10
-      vertex -1.28975 0.162932 10
-      vertex -1.45287 0.373034 10
+      vertex -1.4881716 0.18799973 10
+      vertex -1.2897482 0.1629324 10
+      vertex -1.4528742 0.37303448 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.20871 -0.478561 10
-      vertex -1.39466 -0.552186 10
-      vertex -1.31446 -0.722631 10
+      vertex -1.2087088 -0.4785614 10
+      vertex -1.3946638 -0.552186 10
+      vertex -1.3144598 -0.7226305 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.28975 0.162932 10
-      vertex -1.48817 0.188 10
-      vertex -1.3 0 10
+      vertex -1.2897482 0.1629324 10
+      vertex -1.4881716 0.18799973 10
+      vertex -1.2999992 0 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.25916 -0.323297 10
-      vertex -1.45287 -0.373034 10
-      vertex -1.39466 -0.552186 10
+      vertex -1.2591572 -0.32329655 10
+      vertex -1.4528742 -0.37303448 10
+      vertex -1.3946638 -0.552186 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex -1.5 0 10
-      vertex -1.3 0 10
-      vertex -1.48817 0.188 10
+      vertex -1.2999992 0 10
+      vertex -1.4881716 0.18799973 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.28975 -0.162932 10
-      vertex -1.48817 -0.188 10
-      vertex -1.45287 -0.373034 10
+      vertex -1.2897482 -0.1629324 10
+      vertex -1.4881716 -0.18799973 10
+      vertex -1.4528742 -0.37303448 10
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.3 0 10
+      vertex -1.2999992 0 10
       vertex -1.5 0 10
-      vertex -1.48817 -0.188 10
+      vertex -1.4881716 -0.18799973 10
     endloop
   endfacet
-  facet normal 0.481757 -0.876305 0
+  facet normal 0.36812642 -0.9297758 0
     outer loop
-      vertex 0.638668 -1.35724 0
-      vertex 0.80374 -1.26649 10
-      vertex 0.638668 -1.35724 10
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.46352482 -1.4265842 10
     endloop
   endfacet
-  facet normal 0.481757 -0.876305 0
+  facet normal 0.36812642 -0.9297758 0
     outer loop
-      vertex 0.80374 -1.26649 10
-      vertex 0.638668 -1.35724 0
-      vertex 0.80374 -1.26649 0
+      vertex 0.63866806 -1.3572397 10
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.63866806 -1.3572397 0
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0.68454766 -0.7289681 0
     outer loop
-      vertex 1.3 0 0
-      vertex 1.5 0 0
-      vertex 1.48817 -0.188 0
+      vertex -1.0934525 -1.0268202 0
+      vertex -0.95613575 -1.1557693 10
+      vertex -1.0934525 -1.0268202 10
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0.68454766 -0.7289681 0
     outer loop
-      vertex 1.28975 -0.162932 0
-      vertex 1.48817 -0.188 0
-      vertex 1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.5 0 0
-      vertex 1.3 0 0
-      vertex 1.48817 0.188 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.25916 -0.323297 0
-      vertex 1.45287 -0.373034 0
-      vertex 1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.28975 0.162932 0
-      vertex 1.48817 0.188 0
-      vertex 1.3 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.20871 -0.478561 0
-      vertex 1.39466 -0.552186 0
-      vertex 1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.48817 0.188 0
-      vertex 1.28975 0.162932 0
-      vertex 1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.25916 0.323297 0
-      vertex 1.45287 0.373034 0
-      vertex 1.28975 0.162932 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.48817 -0.188 0
-      vertex 1.28975 -0.162932 0
-      vertex 1.3 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.45287 -0.373034 0
-      vertex 1.25916 -0.323297 0
-      vertex 1.28975 -0.162932 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.1392 -0.626279 0
-      vertex 1.31446 -0.722631 0
-      vertex 1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.39466 -0.552186 0
-      vertex 1.20871 -0.478561 0
-      vertex 1.25916 -0.323297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.31446 -0.722631 0
-      vertex 1.1392 -0.626279 0
-      vertex 1.20871 -0.478561 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.05172 -0.76412 0
-      vertex 1.21352 -0.881678 0
-      vertex 1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.21352 -0.881678 0
-      vertex 1.05172 -0.76412 0
-      vertex 1.1392 -0.626279 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.947659 -0.889911 0
-      vertex 1.09345 -1.02682 0
-      vertex 0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.09345 -1.02682 0
-      vertex 0.947659 -0.889911 0
-      vertex 1.05172 -0.76412 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.956136 -1.15577 0
-      vertex 0.82865 -1.00167 0
-      vertex 0.947659 -0.889911 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.80374 -1.26649 0
-      vertex 0.82865 -1.00167 0
-      vertex 0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.80374 -1.26649 0
-      vertex 0.696574 -1.09763 0
-      vertex 0.82865 -1.00167 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.638668 -1.35724 0
-      vertex 0.696574 -1.09763 0
-      vertex 0.80374 -1.26649 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.638668 -1.35724 0
-      vertex 0.553513 -1.17627 0
-      vertex 0.696574 -1.09763 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.463525 -1.42658 0
-      vertex 0.553513 -1.17627 0
-      vertex 0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.463525 -1.42658 0
-      vertex 0.401722 -1.23637 0
-      vertex 0.553513 -1.17627 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.281072 -1.47343 0
-      vertex 0.401722 -1.23637 0
-      vertex 0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.281072 -1.47343 0
-      vertex 0.243595 -1.27697 0
-      vertex 0.401722 -1.23637 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0941849 -1.49704 0
-      vertex 0.243595 -1.27697 0
-      vertex 0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0941849 -1.49704 0
-      vertex 0.0816269 -1.29743 0
-      vertex 0.243595 -1.27697 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0941849 -1.49704 0
-      vertex -0.0816269 -1.29743 0
-      vertex 0.0816269 -1.29743 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.0941849 -1.49704 0
-      vertex -0.0816269 -1.29743 0
-      vertex 0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.0941849 -1.49704 0
-      vertex -0.243595 -1.27697 0
-      vertex -0.0816269 -1.29743 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.281072 -1.47343 0
-      vertex -0.243595 -1.27697 0
-      vertex -0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.281072 -1.47343 0
-      vertex -0.401722 -1.23637 0
-      vertex -0.243595 -1.27697 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.463525 -1.42658 0
-      vertex -0.401722 -1.23637 0
-      vertex -0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.463525 -1.42658 0
-      vertex -0.553513 -1.17627 0
-      vertex -0.401722 -1.23637 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.638668 -1.35724 0
-      vertex -0.553513 -1.17627 0
-      vertex -0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.638668 -1.35724 0
-      vertex -0.696574 -1.09763 0
-      vertex -0.553513 -1.17627 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.80374 -1.26649 0
-      vertex -0.696574 -1.09763 0
-      vertex -0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.80374 -1.26649 0
-      vertex -0.82865 -1.00167 0
-      vertex -0.696574 -1.09763 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.956136 -1.15577 0
-      vertex -0.82865 -1.00167 0
-      vertex -0.80374 -1.26649 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.82865 -1.00167 0
-      vertex -0.956136 -1.15577 0
-      vertex -0.947659 -0.889911 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.09345 -1.02682 0
-      vertex -0.947659 -0.889911 0
-      vertex -0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.947659 -0.889911 0
-      vertex -1.09345 -1.02682 0
-      vertex -1.05172 -0.76412 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.21352 -0.881678 0
-      vertex -1.05172 -0.76412 0
-      vertex -1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.05172 -0.76412 0
-      vertex -1.21352 -0.881678 0
-      vertex -1.1392 -0.626279 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.31446 -0.722631 0
-      vertex -1.1392 -0.626279 0
-      vertex -1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.1392 -0.626279 0
-      vertex -1.31446 -0.722631 0
-      vertex -1.20871 -0.478561 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.39466 -0.552186 0
-      vertex -1.20871 -0.478561 0
-      vertex -1.31446 -0.722631 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.45287 -0.373034 0
-      vertex -1.25916 -0.323297 0
-      vertex -1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.20871 -0.478561 0
-      vertex -1.39466 -0.552186 0
-      vertex -1.25916 -0.323297 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.45287 0.373034 0
-      vertex 1.25916 0.323297 0
-      vertex 1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.20871 0.478561 0
-      vertex 1.39466 0.552186 0
-      vertex 1.25916 0.323297 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.39466 0.552186 0
-      vertex 1.20871 0.478561 0
-      vertex 1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.1392 0.626279 0
-      vertex 1.31446 0.722631 0
-      vertex 1.20871 0.478561 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.31446 0.722631 0
-      vertex 1.1392 0.626279 0
-      vertex 1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.05172 0.76412 0
-      vertex 1.21352 0.881678 0
-      vertex 1.1392 0.626279 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.21352 0.881678 0
-      vertex 1.05172 0.76412 0
-      vertex 1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.947659 0.889911 0
-      vertex 1.09345 1.02682 0
-      vertex 1.05172 0.76412 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.09345 1.02682 0
-      vertex 0.947659 0.889911 0
-      vertex 0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.82865 1.00167 0
-      vertex 0.956136 1.15577 0
-      vertex 0.947659 0.889911 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.82865 1.00167 0
-      vertex 0.80374 1.26649 0
-      vertex 0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.696574 1.09763 0
-      vertex 0.80374 1.26649 0
-      vertex 0.82865 1.00167 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.696574 1.09763 0
-      vertex 0.638668 1.35724 0
-      vertex 0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.553513 1.17627 0
-      vertex 0.638668 1.35724 0
-      vertex 0.696574 1.09763 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.553513 1.17627 0
-      vertex 0.463525 1.42658 0
-      vertex 0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.401722 1.23637 0
-      vertex 0.463525 1.42658 0
-      vertex 0.553513 1.17627 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.401722 1.23637 0
-      vertex 0.281072 1.47343 0
-      vertex 0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.243595 1.27697 0
-      vertex 0.281072 1.47343 0
-      vertex 0.401722 1.23637 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.243595 1.27697 0
-      vertex 0.0941849 1.49704 0
-      vertex 0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.0816269 1.29743 0
-      vertex 0.0941849 1.49704 0
-      vertex 0.243595 1.27697 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.0816269 1.29743 0
-      vertex 0.0941849 1.49704 0
-      vertex 0.0816269 1.29743 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.0816269 1.29743 0
-      vertex -0.0941849 1.49704 0
-      vertex 0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.243595 1.27697 0
-      vertex -0.0941849 1.49704 0
-      vertex -0.0816269 1.29743 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.243595 1.27697 0
-      vertex -0.281072 1.47343 0
-      vertex -0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.401722 1.23637 0
-      vertex -0.281072 1.47343 0
-      vertex -0.243595 1.27697 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.401722 1.23637 0
-      vertex -0.463525 1.42658 0
-      vertex -0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.553513 1.17627 0
-      vertex -0.463525 1.42658 0
-      vertex -0.401722 1.23637 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.553513 1.17627 0
-      vertex -0.638668 1.35724 0
-      vertex -0.463525 1.42658 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.696574 1.09763 0
-      vertex -0.638668 1.35724 0
-      vertex -0.553513 1.17627 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.696574 1.09763 0
-      vertex -0.80374 1.26649 0
-      vertex -0.638668 1.35724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.82865 1.00167 0
-      vertex -0.80374 1.26649 0
-      vertex -0.696574 1.09763 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.956136 1.15577 0
-      vertex -0.82865 1.00167 0
-      vertex -0.947659 0.889911 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.82865 1.00167 0
-      vertex -0.956136 1.15577 0
-      vertex -0.80374 1.26649 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.09345 1.02682 0
-      vertex -0.947659 0.889911 0
-      vertex -1.05172 0.76412 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.947659 0.889911 0
-      vertex -1.09345 1.02682 0
-      vertex -0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.21352 0.881678 0
-      vertex -1.05172 0.76412 0
-      vertex -1.1392 0.626279 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.31446 0.722631 0
-      vertex -1.1392 0.626279 0
-      vertex -1.20871 0.478561 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.05172 0.76412 0
-      vertex -1.21352 0.881678 0
-      vertex -1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.39466 0.552186 0
-      vertex -1.20871 0.478561 0
-      vertex -1.25916 0.323297 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.45287 0.373034 0
-      vertex -1.25916 0.323297 0
-      vertex -1.28975 0.162932 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.1392 0.626279 0
-      vertex -1.31446 0.722631 0
-      vertex -1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.48817 0.188 0
-      vertex -1.28975 0.162932 0
-      vertex -1.3 0 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.25916 -0.323297 0
-      vertex -1.45287 -0.373034 0
-      vertex -1.28975 -0.162932 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.48817 -0.188 0
-      vertex -1.28975 -0.162932 0
-      vertex -1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.20871 0.478561 0
-      vertex -1.39466 0.552186 0
-      vertex -1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.28975 -0.162932 0
-      vertex -1.48817 -0.188 0
-      vertex -1.3 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.25916 0.323297 0
-      vertex -1.45287 0.373034 0
-      vertex -1.39466 0.552186 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.5 0 0
-      vertex -1.3 0 0
-      vertex -1.48817 -0.188 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.28975 0.162932 0
-      vertex -1.48817 0.188 0
-      vertex -1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.3 0 0
-      vertex -1.5 0 0
-      vertex -1.48817 0.188 0
-    endloop
-  endfacet
-  facet normal -0.125337 -0.992114 0
-    outer loop
-      vertex -0.281072 -1.47343 0
-      vertex -0.0941849 -1.49704 10
-      vertex -0.281072 -1.47343 10
-    endloop
-  endfacet
-  facet normal -0.125337 -0.992114 -0
-    outer loop
-      vertex -0.0941849 -1.49704 10
-      vertex -0.281072 -1.47343 0
-      vertex -0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal -0.904838 0.425756 0
-    outer loop
-      vertex -1.39466 0.552186 0
-      vertex -1.31446 0.722631 10
-      vertex -1.31446 0.722631 0
-    endloop
-  endfacet
-  facet normal -0.904838 0.425756 0
-    outer loop
-      vertex -1.31446 0.722631 10
-      vertex -1.39466 0.552186 0
-      vertex -1.39466 0.552186 10
-    endloop
-  endfacet
-  facet normal -0.770518 -0.637418 0
-    outer loop
-      vertex -1.09345 -1.02682 0
-      vertex -1.21352 -0.881678 10
-      vertex -1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal -0.770518 -0.637418 0
-    outer loop
-      vertex -1.21352 -0.881678 10
-      vertex -1.09345 -1.02682 0
-      vertex -1.09345 -1.02682 10
-    endloop
-  endfacet
-  facet normal -0.125337 0.992114 0
-    outer loop
-      vertex -0.0941849 1.49704 0
-      vertex -0.281072 1.47343 10
-      vertex -0.0941849 1.49704 10
-    endloop
-  endfacet
-  facet normal -0.125337 0.992114 0
-    outer loop
-      vertex -0.281072 1.47343 10
-      vertex -0.0941849 1.49704 0
-      vertex -0.281072 1.47343 0
-    endloop
-  endfacet
-  facet normal 0.684557 -0.728959 0
-    outer loop
-      vertex 0.956136 -1.15577 0
-      vertex 1.09345 -1.02682 10
-      vertex 0.956136 -1.15577 10
-    endloop
-  endfacet
-  facet normal 0.684557 -0.728959 0
-    outer loop
-      vertex 1.09345 -1.02682 10
-      vertex 0.956136 -1.15577 0
-      vertex 1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal -0.904838 -0.425756 0
-    outer loop
-      vertex -1.31446 -0.722631 0
-      vertex -1.39466 -0.552186 10
-      vertex -1.39466 -0.552186 0
-    endloop
-  endfacet
-  facet normal -0.904838 -0.425756 0
-    outer loop
-      vertex -1.39466 -0.552186 10
-      vertex -1.31446 -0.722631 0
-      vertex -1.31446 -0.722631 10
-    endloop
-  endfacet
-  facet normal -0.368106 -0.929784 0
-    outer loop
-      vertex -0.638668 -1.35724 0
-      vertex -0.463525 -1.42658 10
-      vertex -0.638668 -1.35724 10
-    endloop
-  endfacet
-  facet normal -0.368106 -0.929784 -0
-    outer loop
-      vertex -0.463525 -1.42658 10
-      vertex -0.638668 -1.35724 0
-      vertex -0.463525 -1.42658 0
-    endloop
-  endfacet
-  facet normal -0.587778 0.809022 0
-    outer loop
-      vertex -0.80374 1.26649 0
-      vertex -0.956136 1.15577 10
-      vertex -0.80374 1.26649 10
-    endloop
-  endfacet
-  facet normal -0.587778 0.809022 0
-    outer loop
-      vertex -0.956136 1.15577 10
-      vertex -0.80374 1.26649 0
-      vertex -0.956136 1.15577 0
-    endloop
-  endfacet
-  facet normal -0.844314 0.535848 0
-    outer loop
-      vertex -1.31446 0.722631 0
-      vertex -1.21352 0.881678 10
-      vertex -1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal -0.844314 0.535848 0
-    outer loop
-      vertex -1.21352 0.881678 10
-      vertex -1.31446 0.722631 0
-      vertex -1.31446 0.722631 10
-    endloop
-  endfacet
-  facet normal 0.844314 -0.535848 0
-    outer loop
-      vertex 1.21352 -0.881678 10
-      vertex 1.31446 -0.722631 0
-      vertex 1.31446 -0.722631 10
-    endloop
-  endfacet
-  facet normal 0.844314 -0.535848 0
-    outer loop
-      vertex 1.31446 -0.722631 0
-      vertex 1.21352 -0.881678 10
-      vertex 1.21352 -0.881678 0
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.0941849 1.49704 0
-      vertex -0.0941849 1.49704 10
-      vertex 0.0941849 1.49704 10
+      vertex -0.95613575 -1.1557693 10
+      vertex -1.0934525 -1.0268202 0
+      vertex -0.95613575 -1.1557693 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.0941849 1.49704 10
-      vertex 0.0941849 1.49704 0
-      vertex -0.0941849 1.49704 0
-    endloop
-  endfacet
-  facet normal 0.770518 0.637418 0
-    outer loop
-      vertex 1.21352 0.881678 10
-      vertex 1.09345 1.02682 0
-      vertex 1.09345 1.02682 10
-    endloop
-  endfacet
-  facet normal 0.770518 0.637418 0
-    outer loop
-      vertex 1.09345 1.02682 0
-      vertex 1.21352 0.881678 10
-      vertex 1.21352 0.881678 0
-    endloop
-  endfacet
-  facet normal 0.587778 -0.809022 0
-    outer loop
-      vertex 0.80374 -1.26649 0
-      vertex 0.956136 -1.15577 10
-      vertex 0.80374 -1.26649 10
-    endloop
-  endfacet
-  facet normal 0.587778 -0.809022 0
-    outer loop
-      vertex 0.956136 -1.15577 10
-      vertex 0.80374 -1.26649 0
-      vertex 0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal -0.24871 -0.968578 0
-    outer loop
-      vertex -0.463525 -1.42658 0
-      vertex -0.281072 -1.47343 10
-      vertex -0.463525 -1.42658 10
-    endloop
-  endfacet
-  facet normal -0.24871 -0.968578 -0
-    outer loop
-      vertex -0.281072 -1.47343 10
-      vertex -0.463525 -1.42658 0
-      vertex -0.281072 -1.47343 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.0941849 -1.49704 0
-      vertex 0.0941849 -1.49704 10
-      vertex -0.0941849 -1.49704 10
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 0.0941849 -1.49704 10
-      vertex -0.0941849 -1.49704 0
-      vertex 0.0941849 -1.49704 0
-    endloop
-  endfacet
-  facet normal -0.770518 0.637418 0
-    outer loop
-      vertex -1.21352 0.881678 0
-      vertex -1.09345 1.02682 10
-      vertex -1.09345 1.02682 0
-    endloop
-  endfacet
-  facet normal -0.770518 0.637418 0
-    outer loop
-      vertex -1.09345 1.02682 10
-      vertex -1.21352 0.881678 0
-      vertex -1.21352 0.881678 10
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 0
-    outer loop
-      vertex -0.80374 -1.26649 0
-      vertex -0.638668 -1.35724 10
-      vertex -0.80374 -1.26649 10
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 -0
-    outer loop
-      vertex -0.638668 -1.35724 10
-      vertex -0.80374 -1.26649 0
-      vertex -0.638668 -1.35724 0
-    endloop
-  endfacet
-  facet normal -0.684557 -0.728959 0
-    outer loop
-      vertex -1.09345 -1.02682 0
-      vertex -0.956136 -1.15577 10
-      vertex -1.09345 -1.02682 10
-    endloop
-  endfacet
-  facet normal -0.684557 -0.728959 -0
-    outer loop
-      vertex -0.956136 -1.15577 10
-      vertex -1.09345 -1.02682 0
-      vertex -0.956136 -1.15577 0
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309017 0
-    outer loop
-      vertex -1.39466 -0.552186 0
-      vertex -1.45287 -0.373034 10
-      vertex -1.45287 -0.373034 0
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309017 0
-    outer loop
-      vertex -1.45287 -0.373034 10
-      vertex -1.39466 -0.552186 0
-      vertex -1.39466 -0.552186 10
-    endloop
-  endfacet
-  facet normal 0.770518 -0.637418 0
-    outer loop
-      vertex 1.09345 -1.02682 10
-      vertex 1.21352 -0.881678 0
-      vertex 1.21352 -0.881678 10
-    endloop
-  endfacet
-  facet normal 0.770518 -0.637418 0
-    outer loop
-      vertex 1.21352 -0.881678 0
-      vertex 1.09345 -1.02682 10
-      vertex 1.09345 -1.02682 0
-    endloop
-  endfacet
-  facet normal -0.998026 0.0628013 0
-    outer loop
-      vertex -1.5 0 0
-      vertex -1.48817 0.188 10
-      vertex -1.48817 0.188 0
-    endloop
-  endfacet
-  facet normal -0.998026 0.0628013 0
-    outer loop
-      vertex -1.48817 0.188 10
-      vertex -1.5 0 0
-      vertex -1.5 0 10
-    endloop
-  endfacet
-  facet normal -0.982284 0.187396 0
-    outer loop
-      vertex -1.48817 0.188 0
-      vertex -1.45287 0.373034 10
-      vertex -1.45287 0.373034 0
-    endloop
-  endfacet
-  facet normal -0.982284 0.187396 0
-    outer loop
-      vertex -1.45287 0.373034 10
-      vertex -1.48817 0.188 0
-      vertex -1.48817 0.188 10
-    endloop
-  endfacet
-  facet normal 0.844318 0.535842 0
-    outer loop
-      vertex -1.05172 -0.76412 10
-      vertex -1.1392 -0.626279 0
-      vertex -1.1392 -0.626279 10
-    endloop
-  endfacet
-  facet normal 0.844318 0.535842 0
-    outer loop
-      vertex -1.1392 -0.626279 0
-      vertex -1.05172 -0.76412 10
-      vertex -1.05172 -0.76412 0
-    endloop
-  endfacet
-  facet normal -0.58779 0.809014 0
-    outer loop
-      vertex 0.82865 -1.00167 0
-      vertex 0.696574 -1.09763 10
-      vertex 0.82865 -1.00167 10
-    endloop
-  endfacet
-  facet normal -0.58779 0.809014 0
-    outer loop
-      vertex 0.696574 -1.09763 10
-      vertex 0.82865 -1.00167 0
-      vertex 0.696574 -1.09763 0
-    endloop
-  endfacet
-  facet normal -0.982289 -0.187374 0
-    outer loop
-      vertex 1.28975 0.162932 0
-      vertex 1.25916 0.323297 10
-      vertex 1.25916 0.323297 0
-    endloop
-  endfacet
-  facet normal -0.982289 -0.187374 0
-    outer loop
-      vertex 1.25916 0.323297 10
-      vertex 1.28975 0.162932 0
-      vertex 1.28975 0.162932 10
-    endloop
-  endfacet
-  facet normal -0.998027 -0.0627856 0
-    outer loop
-      vertex 1.3 0 0
-      vertex 1.28975 0.162932 10
-      vertex 1.28975 0.162932 0
-    endloop
-  endfacet
-  facet normal -0.998027 -0.0627856 0
-    outer loop
-      vertex 1.28975 0.162932 10
-      vertex 1.3 0 0
-      vertex 1.3 0 10
-    endloop
-  endfacet
-  facet normal -0.951054 -0.309026 0
-    outer loop
-      vertex 1.25916 0.323297 0
-      vertex 1.20871 0.478561 10
-      vertex 1.20871 0.478561 0
-    endloop
-  endfacet
-  facet normal -0.951054 -0.309026 0
-    outer loop
-      vertex 1.20871 0.478561 10
-      vertex 1.25916 0.323297 0
-      vertex 1.25916 0.323297 10
-    endloop
-  endfacet
-  facet normal 0.481714 -0.876329 0
-    outer loop
-      vertex -0.696574 1.09763 0
-      vertex -0.553513 1.17627 10
-      vertex -0.696574 1.09763 10
-    endloop
-  endfacet
-  facet normal 0.481714 -0.876329 0
-    outer loop
-      vertex -0.553513 1.17627 10
-      vertex -0.696574 1.09763 0
-      vertex -0.553513 1.17627 0
-    endloop
-  endfacet
-  facet normal -0.844318 -0.535842 0
-    outer loop
-      vertex 1.1392 0.626279 0
-      vertex 1.05172 0.76412 10
-      vertex 1.05172 0.76412 0
-    endloop
-  endfacet
-  facet normal -0.844318 -0.535842 0
-    outer loop
-      vertex 1.05172 0.76412 10
-      vertex 1.1392 0.626279 0
-      vertex 1.1392 0.626279 10
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.0816269 -1.29743 0
-      vertex -0.0816269 -1.29743 10
-      vertex 0.0816269 -1.29743 10
+      vertex 0.094184875 1.4970398 0
+      vertex -0.094184875 1.4970398 10
+      vertex 0.094184875 1.4970398 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.0816269 -1.29743 10
-      vertex 0.0816269 -1.29743 0
-      vertex -0.0816269 -1.29743 0
+      vertex -0.094184875 1.4970398 10
+      vertex 0.094184875 1.4970398 0
+      vertex -0.094184875 1.4970398 0
     endloop
   endfacet
-  facet normal -0.998027 0.0627856 0
+  facet normal -0.48175356 -0.8763068 0
     outer loop
-      vertex 1.28975 -0.162932 0
-      vertex 1.3 0 10
-      vertex 1.3 0 0
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.80373955 -1.2664909 10
     endloop
   endfacet
-  facet normal -0.998027 0.0627856 0
+  facet normal -0.48175356 -0.8763068 0
     outer loop
-      vertex 1.3 0 10
-      vertex 1.28975 -0.162932 0
-      vertex 1.28975 -0.162932 10
+      vertex -0.63866806 -1.3572397 10
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.63866806 -1.3572397 0
     endloop
   endfacet
-  facet normal -0.248689 0.968583 0
+  facet normal 0.12533255 -0.9921148 0
     outer loop
-      vertex 0.401722 -1.23637 0
-      vertex 0.243595 -1.27697 10
-      vertex 0.401722 -1.23637 10
+      vertex 0.094184875 -1.4970398 0
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.094184875 -1.4970398 10
     endloop
   endfacet
-  facet normal -0.248689 0.968583 0
+  facet normal 0.12533255 -0.9921148 0
     outer loop
-      vertex 0.243595 -1.27697 10
-      vertex 0.401722 -1.23637 0
-      vertex 0.243595 -1.27697 0
+      vertex 0.28107166 -1.4734306 10
+      vertex 0.094184875 -1.4970398 0
+      vertex 0.28107166 -1.4734306 0
     endloop
   endfacet
-  facet normal -0.904829 -0.425775 0
+  facet normal -0.8443265 -0.53582907 0
     outer loop
-      vertex 1.20871 0.478561 0
-      vertex 1.1392 0.626279 10
-      vertex 1.1392 0.626279 0
+      vertex -1.2135248 -0.8816776 0
+      vertex -1.3144598 -0.7226305 10
+      vertex -1.3144598 -0.7226305 0
     endloop
   endfacet
-  facet normal -0.904829 -0.425775 0
+  facet normal -0.8443265 -0.53582907 0
     outer loop
-      vertex 1.1392 0.626279 10
-      vertex 1.20871 0.478561 0
-      vertex 1.20871 0.478561 10
+      vertex -1.3144598 -0.7226305 10
+      vertex -1.2135248 -0.8816776 0
+      vertex -1.2135248 -0.8816776 10
     endloop
   endfacet
-  facet normal 0.951054 -0.309026 0
+  facet normal 0.90482926 -0.4257746 0
     outer loop
-      vertex -1.25916 0.323297 10
-      vertex -1.20871 0.478561 0
-      vertex -1.20871 0.478561 10
+      vertex 1.3144598 -0.7226305 10
+      vertex 1.3946638 -0.552186 0
+      vertex 1.3946638 -0.552186 10
     endloop
   endfacet
-  facet normal 0.951054 -0.309026 0
+  facet normal 0.90482926 -0.4257746 0
     outer loop
-      vertex -1.20871 0.478561 0
-      vertex -1.25916 0.323297 10
-      vertex -1.25916 0.323297 0
+      vertex 1.3946638 -0.552186 0
+      vertex 1.3144598 -0.7226305 10
+      vertex 1.3144598 -0.7226305 0
     endloop
   endfacet
-  facet normal 0.248689 -0.968583 0
+  facet normal 0.99802655 -0.06279307 0
     outer loop
-      vertex -0.401722 1.23637 0
-      vertex -0.243595 1.27697 10
-      vertex -0.401722 1.23637 10
+      vertex 1.4881716 -0.18799973 10
+      vertex 1.5 0 0
+      vertex 1.5 0 10
     endloop
   endfacet
-  facet normal 0.248689 -0.968583 0
+  facet normal 0.99802655 -0.06279307 0
     outer loop
-      vertex -0.243595 1.27697 10
-      vertex -0.401722 1.23637 0
-      vertex -0.243595 1.27697 0
-    endloop
-  endfacet
-  facet normal 0.998027 -0.0627856 0
-    outer loop
-      vertex -1.3 0 10
-      vertex -1.28975 0.162932 0
-      vertex -1.28975 0.162932 10
-    endloop
-  endfacet
-  facet normal 0.998027 -0.0627856 0
-    outer loop
-      vertex -1.28975 0.162932 0
-      vertex -1.3 0 10
-      vertex -1.3 0 0
-    endloop
-  endfacet
-  facet normal -0.77052 -0.637415 0
-    outer loop
-      vertex 1.05172 0.76412 0
-      vertex 0.947659 0.889911 10
-      vertex 0.947659 0.889911 0
-    endloop
-  endfacet
-  facet normal -0.77052 -0.637415 0
-    outer loop
-      vertex 0.947659 0.889911 10
-      vertex 1.05172 0.76412 0
-      vertex 1.05172 0.76412 10
-    endloop
-  endfacet
-  facet normal 0.481714 0.876329 -0
-    outer loop
-      vertex -0.553513 -1.17627 0
-      vertex -0.696574 -1.09763 10
-      vertex -0.553513 -1.17627 10
-    endloop
-  endfacet
-  facet normal 0.481714 0.876329 0
-    outer loop
-      vertex -0.696574 -1.09763 10
-      vertex -0.553513 -1.17627 0
-      vertex -0.696574 -1.09763 0
-    endloop
-  endfacet
-  facet normal 0.58779 0.809014 -0
-    outer loop
-      vertex -0.696574 -1.09763 0
-      vertex -0.82865 -1.00167 10
-      vertex -0.696574 -1.09763 10
-    endloop
-  endfacet
-  facet normal 0.58779 0.809014 0
-    outer loop
-      vertex -0.82865 -1.00167 10
-      vertex -0.696574 -1.09763 0
-      vertex -0.82865 -1.00167 0
-    endloop
-  endfacet
-  facet normal 0.684554 -0.728962 0
-    outer loop
-      vertex -0.947659 0.889911 0
-      vertex -0.82865 1.00167 10
-      vertex -0.947659 0.889911 10
-    endloop
-  endfacet
-  facet normal 0.684554 -0.728962 0
-    outer loop
-      vertex -0.82865 1.00167 10
-      vertex -0.947659 0.889911 0
-      vertex -0.82865 1.00167 0
-    endloop
-  endfacet
-  facet normal -0.481714 -0.876329 0
-    outer loop
-      vertex 0.553513 1.17627 0
-      vertex 0.696574 1.09763 10
-      vertex 0.553513 1.17627 10
-    endloop
-  endfacet
-  facet normal -0.481714 -0.876329 -0
-    outer loop
-      vertex 0.696574 1.09763 10
-      vertex 0.553513 1.17627 0
-      vertex 0.696574 1.09763 0
-    endloop
-  endfacet
-  facet normal -0.77052 0.637415 0
-    outer loop
-      vertex 0.947659 -0.889911 0
-      vertex 1.05172 -0.76412 10
-      vertex 1.05172 -0.76412 0
-    endloop
-  endfacet
-  facet normal -0.77052 0.637415 0
-    outer loop
-      vertex 1.05172 -0.76412 10
-      vertex 0.947659 -0.889911 0
-      vertex 0.947659 -0.889911 10
-    endloop
-  endfacet
-  facet normal -0.125325 0.992116 0
-    outer loop
-      vertex 0.243595 -1.27697 0
-      vertex 0.0816269 -1.29743 10
-      vertex 0.243595 -1.27697 10
-    endloop
-  endfacet
-  facet normal -0.125325 0.992116 0
-    outer loop
-      vertex 0.0816269 -1.29743 10
-      vertex 0.243595 -1.27697 0
-      vertex 0.0816269 -1.29743 0
-    endloop
-  endfacet
-  facet normal -0.58779 -0.809014 0
-    outer loop
-      vertex 0.696574 1.09763 0
-      vertex 0.82865 1.00167 10
-      vertex 0.696574 1.09763 10
-    endloop
-  endfacet
-  facet normal -0.58779 -0.809014 -0
-    outer loop
-      vertex 0.82865 1.00167 10
-      vertex 0.696574 1.09763 0
-      vertex 0.82865 1.00167 0
-    endloop
-  endfacet
-  facet normal 0.77052 0.637415 0
-    outer loop
-      vertex -0.947659 -0.889911 10
-      vertex -1.05172 -0.76412 0
-      vertex -1.05172 -0.76412 10
-    endloop
-  endfacet
-  facet normal 0.77052 0.637415 0
-    outer loop
-      vertex -1.05172 -0.76412 0
-      vertex -0.947659 -0.889911 10
-      vertex -0.947659 -0.889911 0
-    endloop
-  endfacet
-  facet normal 0.951054 0.309026 0
-    outer loop
-      vertex -1.20871 -0.478561 10
-      vertex -1.25916 -0.323297 0
-      vertex -1.25916 -0.323297 10
-    endloop
-  endfacet
-  facet normal 0.951054 0.309026 0
-    outer loop
-      vertex -1.25916 -0.323297 0
-      vertex -1.20871 -0.478561 10
-      vertex -1.20871 -0.478561 0
-    endloop
-  endfacet
-  facet normal -0.982289 0.187374 0
-    outer loop
-      vertex 1.25916 -0.323297 0
-      vertex 1.28975 -0.162932 10
-      vertex 1.28975 -0.162932 0
-    endloop
-  endfacet
-  facet normal -0.982289 0.187374 0
-    outer loop
-      vertex 1.28975 -0.162932 10
-      vertex 1.25916 -0.323297 0
-      vertex 1.25916 -0.323297 10
-    endloop
-  endfacet
-  facet normal 0.368134 -0.929773 0
-    outer loop
-      vertex -0.553513 1.17627 0
-      vertex -0.401722 1.23637 10
-      vertex -0.553513 1.17627 10
-    endloop
-  endfacet
-  facet normal 0.368134 -0.929773 0
-    outer loop
-      vertex -0.401722 1.23637 10
-      vertex -0.553513 1.17627 0
-      vertex -0.401722 1.23637 0
-    endloop
-  endfacet
-  facet normal -0.844318 0.535842 0
-    outer loop
-      vertex 1.05172 -0.76412 0
-      vertex 1.1392 -0.626279 10
-      vertex 1.1392 -0.626279 0
-    endloop
-  endfacet
-  facet normal -0.844318 0.535842 0
-    outer loop
-      vertex 1.1392 -0.626279 10
-      vertex 1.05172 -0.76412 0
-      vertex 1.05172 -0.76412 10
-    endloop
-  endfacet
-  facet normal -0.481714 0.876329 0
-    outer loop
-      vertex 0.696574 -1.09763 0
-      vertex 0.553513 -1.17627 10
-      vertex 0.696574 -1.09763 10
-    endloop
-  endfacet
-  facet normal -0.481714 0.876329 0
-    outer loop
-      vertex 0.553513 -1.17627 10
-      vertex 0.696574 -1.09763 0
-      vertex 0.553513 -1.17627 0
-    endloop
-  endfacet
-  facet normal -0.904829 0.425775 0
-    outer loop
-      vertex 1.1392 -0.626279 0
-      vertex 1.20871 -0.478561 10
-      vertex 1.20871 -0.478561 0
-    endloop
-  endfacet
-  facet normal -0.904829 0.425775 0
-    outer loop
-      vertex 1.20871 -0.478561 10
-      vertex 1.1392 -0.626279 0
-      vertex 1.1392 -0.626279 10
-    endloop
-  endfacet
-  facet normal -0.248689 -0.968583 0
-    outer loop
-      vertex 0.243595 1.27697 0
-      vertex 0.401722 1.23637 10
-      vertex 0.243595 1.27697 10
-    endloop
-  endfacet
-  facet normal -0.248689 -0.968583 -0
-    outer loop
-      vertex 0.401722 1.23637 10
-      vertex 0.243595 1.27697 0
-      vertex 0.401722 1.23637 0
-    endloop
-  endfacet
-  facet normal 0.684554 0.728962 -0
-    outer loop
-      vertex -0.82865 -1.00167 0
-      vertex -0.947659 -0.889911 10
-      vertex -0.82865 -1.00167 10
-    endloop
-  endfacet
-  facet normal 0.684554 0.728962 0
-    outer loop
-      vertex -0.947659 -0.889911 10
-      vertex -0.82865 -1.00167 0
-      vertex -0.947659 -0.889911 0
-    endloop
-  endfacet
-  facet normal 0.904829 0.425775 0
-    outer loop
-      vertex -1.1392 -0.626279 10
-      vertex -1.20871 -0.478561 0
-      vertex -1.20871 -0.478561 10
-    endloop
-  endfacet
-  facet normal 0.904829 0.425775 0
-    outer loop
-      vertex -1.20871 -0.478561 0
-      vertex -1.1392 -0.626279 10
-      vertex -1.1392 -0.626279 0
+      vertex 1.5 0 0
+      vertex 1.4881716 -0.18799973 10
+      vertex 1.4881716 -0.18799973 0
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -0.0816269 1.29743 0
-      vertex 0.0816269 1.29743 10
-      vertex -0.0816269 1.29743 10
+      vertex -0.094184875 -1.4970398 0
+      vertex 0.094184875 -1.4970398 10
+      vertex -0.094184875 -1.4970398 10
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 -1 0
     outer loop
-      vertex 0.0816269 1.29743 10
-      vertex -0.0816269 1.29743 0
-      vertex 0.0816269 1.29743 0
+      vertex 0.094184875 -1.4970398 10
+      vertex -0.094184875 -1.4970398 0
+      vertex 0.094184875 -1.4970398 0
     endloop
   endfacet
-  facet normal -0.951054 0.309026 0
+  facet normal -0.12533255 0.9921148 0
     outer loop
-      vertex 1.20871 -0.478561 0
-      vertex 1.25916 -0.323297 10
-      vertex 1.25916 -0.323297 0
+      vertex -0.094184875 1.4970398 0
+      vertex -0.28107166 1.4734306 10
+      vertex -0.094184875 1.4970398 10
     endloop
   endfacet
-  facet normal -0.951054 0.309026 0
+  facet normal -0.12533255 0.9921148 0
     outer loop
-      vertex 1.25916 -0.323297 10
-      vertex 1.20871 -0.478561 0
-      vertex 1.20871 -0.478561 10
+      vertex -0.28107166 1.4734306 10
+      vertex -0.094184875 1.4970398 0
+      vertex -0.28107166 1.4734306 0
     endloop
   endfacet
-  facet normal -0.368134 0.929773 0
+  facet normal 0.48175356 0.8763068 0
     outer loop
-      vertex 0.553513 -1.17627 0
-      vertex 0.401722 -1.23637 10
-      vertex 0.553513 -1.17627 10
+      vertex 0.80373955 1.2664909 0
+      vertex 0.63866806 1.3572397 10
+      vertex 0.80373955 1.2664909 10
     endloop
   endfacet
-  facet normal -0.368134 0.929773 0
+  facet normal 0.48175356 0.8763068 0
     outer loop
-      vertex 0.401722 -1.23637 10
-      vertex 0.553513 -1.17627 0
-      vertex 0.401722 -1.23637 0
+      vertex 0.63866806 1.3572397 10
+      vertex 0.80373955 1.2664909 0
+      vertex 0.63866806 1.3572397 0
     endloop
   endfacet
-  facet normal -0.125325 -0.992116 0
+  facet normal -0.12533255 -0.9921148 0
     outer loop
-      vertex 0.0816269 1.29743 0
-      vertex 0.243595 1.27697 10
-      vertex 0.0816269 1.29743 10
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.094184875 -1.4970398 10
+      vertex -0.28107166 -1.4734306 10
     endloop
   endfacet
-  facet normal -0.125325 -0.992116 -0
+  facet normal -0.12533255 -0.9921148 0
     outer loop
-      vertex 0.243595 1.27697 10
-      vertex 0.0816269 1.29743 0
-      vertex 0.243595 1.27697 0
+      vertex -0.094184875 -1.4970398 10
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.094184875 -1.4970398 0
     endloop
   endfacet
-  facet normal -0.368134 -0.929773 0
+  facet normal 0.68454766 -0.7289681 0
     outer loop
-      vertex 0.401722 1.23637 0
-      vertex 0.553513 1.17627 10
-      vertex 0.401722 1.23637 10
+      vertex 0.95613575 -1.1557693 0
+      vertex 1.0934525 -1.0268202 10
+      vertex 0.95613575 -1.1557693 10
     endloop
   endfacet
-  facet normal -0.368134 -0.929773 -0
+  facet normal 0.68454766 -0.7289681 0
     outer loop
-      vertex 0.553513 1.17627 10
-      vertex 0.401722 1.23637 0
-      vertex 0.553513 1.17627 0
+      vertex 1.0934525 -1.0268202 10
+      vertex 0.95613575 -1.1557693 0
+      vertex 1.0934525 -1.0268202 0
     endloop
   endfacet
-  facet normal 0.248689 0.968583 -0
+  facet normal -0.68454766 0.7289681 0
     outer loop
-      vertex -0.243595 -1.27697 0
-      vertex -0.401722 -1.23637 10
-      vertex -0.243595 -1.27697 10
+      vertex -0.95613575 1.1557693 0
+      vertex -1.0934525 1.0268202 10
+      vertex -0.95613575 1.1557693 10
     endloop
   endfacet
-  facet normal 0.248689 0.968583 0
+  facet normal -0.68454766 0.7289681 0
     outer loop
-      vertex -0.401722 -1.23637 10
-      vertex -0.243595 -1.27697 0
-      vertex -0.401722 -1.23637 0
+      vertex -1.0934525 1.0268202 10
+      vertex -0.95613575 1.1557693 0
+      vertex -1.0934525 1.0268202 0
     endloop
   endfacet
-  facet normal -0.684554 0.728962 0
+  facet normal 0.9822871 -0.18738197 0
     outer loop
-      vertex 0.947659 -0.889911 0
-      vertex 0.82865 -1.00167 10
-      vertex 0.947659 -0.889911 10
+      vertex 1.4528742 -0.37303448 10
+      vertex 1.4881716 -0.18799973 0
+      vertex 1.4881716 -0.18799973 10
     endloop
   endfacet
-  facet normal -0.684554 0.728962 0
+  facet normal 0.9822871 -0.18738197 0
     outer loop
-      vertex 0.82865 -1.00167 10
-      vertex 0.947659 -0.889911 0
-      vertex 0.82865 -1.00167 0
+      vertex 1.4881716 -0.18799973 0
+      vertex 1.4528742 -0.37303448 10
+      vertex 1.4528742 -0.37303448 0
     endloop
   endfacet
-  facet normal -0.684554 -0.728962 0
+  facet normal 0.9822871 0.18738197 0
     outer loop
-      vertex 0.82865 1.00167 0
-      vertex 0.947659 0.889911 10
-      vertex 0.82865 1.00167 10
+      vertex 1.4881716 0.18799973 10
+      vertex 1.4528742 0.37303448 0
+      vertex 1.4528742 0.37303448 10
     endloop
   endfacet
-  facet normal -0.684554 -0.728962 -0
+  facet normal 0.9822871 0.18738197 0
     outer loop
-      vertex 0.947659 0.889911 10
-      vertex 0.82865 1.00167 0
-      vertex 0.947659 0.889911 0
+      vertex 1.4528742 0.37303448 0
+      vertex 1.4881716 0.18799973 10
+      vertex 1.4881716 0.18799973 0
     endloop
   endfacet
-  facet normal 0.368134 0.929773 -0
+  facet normal 0.90482926 0.4257746 0
     outer loop
-      vertex -0.401722 -1.23637 0
-      vertex -0.553513 -1.17627 10
-      vertex -0.401722 -1.23637 10
+      vertex 1.3946638 0.552186 10
+      vertex 1.3144598 0.7226305 0
+      vertex 1.3144598 0.7226305 10
     endloop
   endfacet
-  facet normal 0.368134 0.929773 0
+  facet normal 0.90482926 0.4257746 0
     outer loop
-      vertex -0.553513 -1.17627 10
-      vertex -0.401722 -1.23637 0
-      vertex -0.553513 -1.17627 0
+      vertex 1.3144598 0.7226305 0
+      vertex 1.3946638 0.552186 10
+      vertex 1.3946638 0.552186 0
     endloop
   endfacet
-  facet normal 0.125325 0.992116 -0
+  facet normal -0.8443265 0.53582907 0
     outer loop
-      vertex -0.0816269 -1.29743 0
-      vertex -0.243595 -1.27697 10
-      vertex -0.0816269 -1.29743 10
+      vertex -1.3144598 0.7226305 0
+      vertex -1.2135248 0.8816776 10
+      vertex -1.2135248 0.8816776 0
     endloop
   endfacet
-  facet normal 0.125325 0.992116 0
+  facet normal -0.8443265 0.53582907 0
     outer loop
-      vertex -0.243595 -1.27697 10
-      vertex -0.0816269 -1.29743 0
-      vertex -0.243595 -1.27697 0
+      vertex -1.2135248 0.8816776 10
+      vertex -1.3144598 0.7226305 0
+      vertex -1.3144598 0.7226305 10
     endloop
   endfacet
-  facet normal 0.998027 0.0627856 0
+  facet normal -0.90482926 -0.4257746 0
     outer loop
-      vertex -1.28975 -0.162932 10
-      vertex -1.3 0 0
-      vertex -1.3 0 10
+      vertex -1.3144598 -0.7226305 0
+      vertex -1.3946638 -0.552186 10
+      vertex -1.3946638 -0.552186 0
     endloop
   endfacet
-  facet normal 0.998027 0.0627856 0
+  facet normal -0.90482926 -0.4257746 0
     outer loop
-      vertex -1.3 0 0
-      vertex -1.28975 -0.162932 10
-      vertex -1.28975 -0.162932 0
+      vertex -1.3946638 -0.552186 10
+      vertex -1.3144598 -0.7226305 0
+      vertex -1.3144598 -0.7226305 10
     endloop
   endfacet
-  facet normal 0.125325 -0.992116 0
+  facet normal -0.77051324 0.637424 0
     outer loop
-      vertex -0.243595 1.27697 0
-      vertex -0.0816269 1.29743 10
-      vertex -0.243595 1.27697 10
+      vertex -1.2135248 0.8816776 0
+      vertex -1.0934525 1.0268202 10
+      vertex -1.0934525 1.0268202 0
     endloop
   endfacet
-  facet normal 0.125325 -0.992116 0
+  facet normal -0.77051324 0.637424 0
     outer loop
-      vertex -0.0816269 1.29743 10
-      vertex -0.243595 1.27697 0
-      vertex -0.0816269 1.29743 0
+      vertex -1.0934525 1.0268202 10
+      vertex -1.2135248 0.8816776 0
+      vertex -1.2135248 0.8816776 10
     endloop
   endfacet
-  facet normal 0.844318 -0.535842 0
+  facet normal -0.90482926 0.4257746 0
     outer loop
-      vertex -1.1392 0.626279 10
-      vertex -1.05172 0.76412 0
-      vertex -1.05172 0.76412 10
+      vertex -1.3946638 0.552186 0
+      vertex -1.3144598 0.7226305 10
+      vertex -1.3144598 0.7226305 0
     endloop
   endfacet
-  facet normal 0.844318 -0.535842 0
+  facet normal -0.90482926 0.4257746 0
     outer loop
-      vertex -1.05172 0.76412 0
-      vertex -1.1392 0.626279 10
-      vertex -1.1392 0.626279 0
+      vertex -1.3144598 0.7226305 10
+      vertex -1.3946638 0.552186 0
+      vertex -1.3946638 0.552186 10
     endloop
   endfacet
-  facet normal 0.982289 0.187374 0
+  facet normal 0.8443265 -0.53582907 0
     outer loop
-      vertex -1.25916 -0.323297 10
-      vertex -1.28975 -0.162932 0
-      vertex -1.28975 -0.162932 10
+      vertex 1.2135248 -0.8816776 10
+      vertex 1.3144598 -0.7226305 0
+      vertex 1.3144598 -0.7226305 10
     endloop
   endfacet
-  facet normal 0.982289 0.187374 0
+  facet normal 0.8443265 -0.53582907 0
     outer loop
-      vertex -1.28975 -0.162932 0
-      vertex -1.25916 -0.323297 10
-      vertex -1.25916 -0.323297 0
+      vertex 1.3144598 -0.7226305 0
+      vertex 1.2135248 -0.8816776 10
+      vertex 1.2135248 -0.8816776 0
     endloop
   endfacet
-  facet normal 0.58779 -0.809014 0
+  facet normal -0.99802655 0.06279307 0
     outer loop
-      vertex -0.82865 1.00167 0
-      vertex -0.696574 1.09763 10
-      vertex -0.82865 1.00167 10
+      vertex -1.5 0 0
+      vertex -1.4881716 0.18799973 10
+      vertex -1.4881716 0.18799973 0
     endloop
   endfacet
-  facet normal 0.58779 -0.809014 0
+  facet normal -0.99802655 0.06279307 0
     outer loop
-      vertex -0.696574 1.09763 10
-      vertex -0.82865 1.00167 0
-      vertex -0.696574 1.09763 0
+      vertex -1.4881716 0.18799973 10
+      vertex -1.5 0 0
+      vertex -1.5 0 10
     endloop
   endfacet
-  facet normal 0.904829 -0.425775 0
+  facet normal -0.99802655 -0.06279307 0
     outer loop
-      vertex -1.20871 0.478561 10
-      vertex -1.1392 0.626279 0
-      vertex -1.1392 0.626279 10
+      vertex -1.4881716 -0.18799973 0
+      vertex -1.5 0 10
+      vertex -1.5 0 0
     endloop
   endfacet
-  facet normal 0.904829 -0.425775 0
+  facet normal -0.99802655 -0.06279307 0
     outer loop
-      vertex -1.1392 0.626279 0
-      vertex -1.20871 0.478561 10
-      vertex -1.20871 0.478561 0
+      vertex -1.5 0 10
+      vertex -1.4881716 -0.18799973 0
+      vertex -1.4881716 -0.18799973 10
     endloop
   endfacet
-  facet normal 0.982289 -0.187374 0
+  facet normal 0.68454766 0.7289681 0
     outer loop
-      vertex -1.28975 0.162932 10
-      vertex -1.25916 0.323297 0
-      vertex -1.25916 0.323297 10
+      vertex 1.0934525 1.0268202 0
+      vertex 0.95613575 1.1557693 10
+      vertex 1.0934525 1.0268202 10
     endloop
   endfacet
-  facet normal 0.982289 -0.187374 0
+  facet normal 0.68454766 0.7289681 0
     outer loop
-      vertex -1.25916 0.323297 0
-      vertex -1.28975 0.162932 10
-      vertex -1.28975 0.162932 0
+      vertex 0.95613575 1.1557693 10
+      vertex 1.0934525 1.0268202 0
+      vertex 0.95613575 1.1557693 0
     endloop
   endfacet
-  facet normal 0.77052 -0.637415 0
+  facet normal 0.8443265 0.53582907 0
     outer loop
-      vertex -1.05172 0.76412 10
-      vertex -0.947659 0.889911 0
-      vertex -0.947659 0.889911 10
+      vertex 1.3144598 0.7226305 10
+      vertex 1.2135248 0.8816776 0
+      vertex 1.2135248 0.8816776 10
     endloop
   endfacet
-  facet normal 0.77052 -0.637415 0
+  facet normal 0.8443265 0.53582907 0
     outer loop
-      vertex -0.947659 0.889911 0
-      vertex -1.05172 0.76412 10
-      vertex -1.05172 0.76412 0
+      vertex 1.2135248 0.8816776 0
+      vertex 1.3144598 0.7226305 10
+      vertex 1.3144598 0.7226305 0
+    endloop
+  endfacet
+  facet normal 0.12533255 0.9921148 0
+    outer loop
+      vertex 0.28107166 1.4734306 0
+      vertex 0.094184875 1.4970398 10
+      vertex 0.28107166 1.4734306 10
+    endloop
+  endfacet
+  facet normal 0.12533255 0.9921148 0
+    outer loop
+      vertex 0.094184875 1.4970398 10
+      vertex 0.28107166 1.4734306 0
+      vertex 0.094184875 1.4970398 0
+    endloop
+  endfacet
+  facet normal 0.9510557 0.30901945 0
+    outer loop
+      vertex 1.4528742 0.37303448 10
+      vertex 1.3946638 0.552186 0
+      vertex 1.3946638 0.552186 10
+    endloop
+  endfacet
+  facet normal 0.9510557 0.30901945 0
+    outer loop
+      vertex 1.3946638 0.552186 0
+      vertex 1.4528742 0.37303448 10
+      vertex 1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal -0.9510557 -0.30901945 0
+    outer loop
+      vertex -1.3946638 -0.552186 0
+      vertex -1.4528742 -0.37303448 10
+      vertex -1.4528742 -0.37303448 0
+    endloop
+  endfacet
+  facet normal -0.9510557 -0.30901945 0
+    outer loop
+      vertex -1.4528742 -0.37303448 10
+      vertex -1.3946638 -0.552186 0
+      vertex -1.3946638 -0.552186 10
+    endloop
+  endfacet
+  facet normal -0.24869178 -0.9685827 0
+    outer loop
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.46352482 -1.4265842 10
+    endloop
+  endfacet
+  facet normal -0.24869178 -0.9685827 0
+    outer loop
+      vertex -0.28107166 -1.4734306 10
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.28107166 -1.4734306 0
+    endloop
+  endfacet
+  facet normal 0.36812642 0.9297758 0
+    outer loop
+      vertex 0.63866806 1.3572397 0
+      vertex 0.46352482 1.4265842 10
+      vertex 0.63866806 1.3572397 10
+    endloop
+  endfacet
+  facet normal 0.36812642 0.9297758 0
+    outer loop
+      vertex 0.46352482 1.4265842 10
+      vertex 0.63866806 1.3572397 0
+      vertex 0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal 0.24869178 -0.9685827 0
+    outer loop
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.28107166 -1.4734306 10
+    endloop
+  endfacet
+  facet normal 0.24869178 -0.9685827 0
+    outer loop
+      vertex 0.46352482 -1.4265842 10
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal 0.5877827 0.80901885 0
+    outer loop
+      vertex 0.95613575 1.1557693 0
+      vertex 0.80373955 1.2664909 10
+      vertex 0.95613575 1.1557693 10
+    endloop
+  endfacet
+  facet normal 0.5877827 0.80901885 0
+    outer loop
+      vertex 0.80373955 1.2664909 10
+      vertex 0.95613575 1.1557693 0
+      vertex 0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0.9510557 -0.30901945 0
+    outer loop
+      vertex 1.3946638 -0.552186 10
+      vertex 1.4528742 -0.37303448 0
+      vertex 1.4528742 -0.37303448 10
+    endloop
+  endfacet
+  facet normal 0.9510557 -0.30901945 0
+    outer loop
+      vertex 1.4528742 -0.37303448 0
+      vertex 1.3946638 -0.552186 10
+      vertex 1.3946638 -0.552186 0
+    endloop
+  endfacet
+  facet normal -0.77051324 -0.637424 0
+    outer loop
+      vertex -1.0934525 -1.0268202 0
+      vertex -1.2135248 -0.8816776 10
+      vertex -1.2135248 -0.8816776 0
+    endloop
+  endfacet
+  facet normal -0.77051324 -0.637424 0
+    outer loop
+      vertex -1.2135248 -0.8816776 10
+      vertex -1.0934525 -1.0268202 0
+      vertex -1.0934525 -1.0268202 10
+    endloop
+  endfacet
+  facet normal -0.9822871 -0.18738197 0
+    outer loop
+      vertex -1.4528742 -0.37303448 0
+      vertex -1.4881716 -0.18799973 10
+      vertex -1.4881716 -0.18799973 0
+    endloop
+  endfacet
+  facet normal -0.9822871 -0.18738197 0
+    outer loop
+      vertex -1.4881716 -0.18799973 10
+      vertex -1.4528742 -0.37303448 0
+      vertex -1.4528742 -0.37303448 10
+    endloop
+  endfacet
+  facet normal -0.9822871 0.18738197 0
+    outer loop
+      vertex -1.4881716 0.18799973 0
+      vertex -1.4528742 0.37303448 10
+      vertex -1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal -0.9822871 0.18738197 0
+    outer loop
+      vertex -1.4528742 0.37303448 10
+      vertex -1.4881716 0.18799973 0
+      vertex -1.4881716 0.18799973 10
+    endloop
+  endfacet
+  facet normal 0.77051324 -0.637424 0
+    outer loop
+      vertex 1.0934525 -1.0268202 10
+      vertex 1.2135248 -0.8816776 0
+      vertex 1.2135248 -0.8816776 10
+    endloop
+  endfacet
+  facet normal 0.77051324 -0.637424 0
+    outer loop
+      vertex 1.2135248 -0.8816776 0
+      vertex 1.0934525 -1.0268202 10
+      vertex 1.0934525 -1.0268202 0
+    endloop
+  endfacet
+  facet normal -0.36812642 -0.9297758 0
+    outer loop
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.63866806 -1.3572397 10
+    endloop
+  endfacet
+  facet normal -0.36812642 -0.9297758 0
+    outer loop
+      vertex -0.46352482 -1.4265842 10
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal -0.24869178 0.9685827 0
+    outer loop
+      vertex -0.28107166 1.4734306 0
+      vertex -0.46352482 1.4265842 10
+      vertex -0.28107166 1.4734306 10
+    endloop
+  endfacet
+  facet normal -0.24869178 0.9685827 0
+    outer loop
+      vertex -0.46352482 1.4265842 10
+      vertex -0.28107166 1.4734306 0
+      vertex -0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal -0.48175356 0.8763068 0
+    outer loop
+      vertex -0.63866806 1.3572397 0
+      vertex -0.80373955 1.2664909 10
+      vertex -0.63866806 1.3572397 10
+    endloop
+  endfacet
+  facet normal -0.48175356 0.8763068 0
+    outer loop
+      vertex -0.80373955 1.2664909 10
+      vertex -0.63866806 1.3572397 0
+      vertex -0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0.5877827 -0.80901885 0
+    outer loop
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.95613575 -1.1557693 10
+      vertex 0.80373955 -1.2664909 10
+    endloop
+  endfacet
+  facet normal 0.5877827 -0.80901885 0
+    outer loop
+      vertex 0.95613575 -1.1557693 10
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.95613575 -1.1557693 0
+    endloop
+  endfacet
+  facet normal -0.9510557 0.30901945 0
+    outer loop
+      vertex -1.4528742 0.37303448 0
+      vertex -1.3946638 0.552186 10
+      vertex -1.3946638 0.552186 0
+    endloop
+  endfacet
+  facet normal -0.9510557 0.30901945 0
+    outer loop
+      vertex -1.3946638 0.552186 10
+      vertex -1.4528742 0.37303448 0
+      vertex -1.4528742 0.37303448 10
+    endloop
+  endfacet
+  facet normal -0.5877827 0.80901885 0
+    outer loop
+      vertex -0.80373955 1.2664909 0
+      vertex -0.95613575 1.1557693 10
+      vertex -0.80373955 1.2664909 10
+    endloop
+  endfacet
+  facet normal -0.5877827 0.80901885 0
+    outer loop
+      vertex -0.95613575 1.1557693 10
+      vertex -0.80373955 1.2664909 0
+      vertex -0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal -0.36812642 0.9297758 0
+    outer loop
+      vertex -0.46352482 1.4265842 0
+      vertex -0.63866806 1.3572397 10
+      vertex -0.46352482 1.4265842 10
+    endloop
+  endfacet
+  facet normal -0.36812642 0.9297758 0
+    outer loop
+      vertex -0.63866806 1.3572397 10
+      vertex -0.46352482 1.4265842 0
+      vertex -0.63866806 1.3572397 0
+    endloop
+  endfacet
+  facet normal -0.5877827 -0.80901885 0
+    outer loop
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.95613575 -1.1557693 10
+    endloop
+  endfacet
+  facet normal -0.5877827 -0.80901885 0
+    outer loop
+      vertex -0.80373955 -1.2664909 10
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.80373955 -1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2999992 0 0
+      vertex 1.5 0 0
+      vertex 1.4881716 -0.18799973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2897482 -0.1629324 0
+      vertex 1.4881716 -0.18799973 0
+      vertex 1.4528742 -0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.5 0 0
+      vertex 1.2999992 0 0
+      vertex 1.4881716 0.18799973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2591572 -0.32329655 0
+      vertex 1.4528742 -0.37303448 0
+      vertex 1.3946638 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2897482 0.1629324 0
+      vertex 1.4881716 0.18799973 0
+      vertex 1.2999992 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2087088 -0.4785614 0
+      vertex 1.3946638 -0.552186 0
+      vertex 1.3144598 -0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4881716 0.18799973 0
+      vertex 1.2897482 0.1629324 0
+      vertex 1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2591572 0.32329655 0
+      vertex 1.4528742 0.37303448 0
+      vertex 1.2897482 0.1629324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4881716 -0.18799973 0
+      vertex 1.2897482 -0.1629324 0
+      vertex 1.2999992 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4528742 -0.37303448 0
+      vertex 1.2591572 -0.32329655 0
+      vertex 1.2897482 -0.1629324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.1391983 -0.6262789 0
+      vertex 1.3144598 -0.7226305 0
+      vertex 1.2135248 -0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3946638 -0.552186 0
+      vertex 1.2087088 -0.4785614 0
+      vertex 1.2591572 -0.32329655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3144598 -0.7226305 0
+      vertex 1.1391983 -0.6262789 0
+      vertex 1.2087088 -0.4785614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0517216 -0.7641201 0
+      vertex 1.2135248 -0.8816776 0
+      vertex 1.0934525 -1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2135248 -0.8816776 0
+      vertex 1.0517216 -0.7641201 0
+      vertex 1.1391983 -0.6262789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.94765854 -0.8899107 0
+      vertex 1.0934525 -1.0268202 0
+      vertex 0.95613575 -1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0934525 -1.0268202 0
+      vertex 0.94765854 -0.8899107 0
+      vertex 1.0517216 -0.7641201 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.95613575 -1.1557693 0
+      vertex 0.8286505 -1.001667 0
+      vertex 0.94765854 -0.8899107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.8286505 -1.001667 0
+      vertex 0.95613575 -1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.80373955 -1.2664909 0
+      vertex 0.6965742 -1.0976257 0
+      vertex 0.8286505 -1.001667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.6965742 -1.0976257 0
+      vertex 0.80373955 -1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.63866806 -1.3572397 0
+      vertex 0.5535126 -1.1762743 0
+      vertex 0.6965742 -1.0976257 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.5535126 -1.1762743 0
+      vertex 0.63866806 -1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46352482 -1.4265842 0
+      vertex 0.40172195 -1.236373 0
+      vertex 0.5535126 -1.1762743 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.40172195 -1.236373 0
+      vertex 0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.28107166 -1.4734306 0
+      vertex 0.24359512 -1.2769728 0
+      vertex 0.40172195 -1.236373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.094184875 -1.4970398 0
+      vertex 0.24359512 -1.2769728 0
+      vertex 0.28107166 -1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.094184875 -1.4970398 0
+      vertex 0.08162689 -1.2974339 0
+      vertex 0.24359512 -1.2769728 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.094184875 -1.4970398 0
+      vertex -0.08162689 -1.2974339 0
+      vertex 0.08162689 -1.2974339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.094184875 -1.4970398 0
+      vertex -0.08162689 -1.2974339 0
+      vertex 0.094184875 -1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.094184875 -1.4970398 0
+      vertex -0.24359512 -1.2769728 0
+      vertex -0.08162689 -1.2974339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.24359512 -1.2769728 0
+      vertex -0.094184875 -1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.28107166 -1.4734306 0
+      vertex -0.40172195 -1.236373 0
+      vertex -0.24359512 -1.2769728 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.40172195 -1.236373 0
+      vertex -0.28107166 -1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46352482 -1.4265842 0
+      vertex -0.5535126 -1.1762743 0
+      vertex -0.40172195 -1.236373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.5535126 -1.1762743 0
+      vertex -0.46352482 -1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.63866806 -1.3572397 0
+      vertex -0.6965742 -1.0976257 0
+      vertex -0.5535126 -1.1762743 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.6965742 -1.0976257 0
+      vertex -0.63866806 -1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.80373955 -1.2664909 0
+      vertex -0.8286505 -1.001667 0
+      vertex -0.6965742 -1.0976257 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.8286505 -1.001667 0
+      vertex -0.80373955 -1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.8286505 -1.001667 0
+      vertex -0.95613575 -1.1557693 0
+      vertex -0.94765854 -0.8899107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0934525 -1.0268202 0
+      vertex -0.94765854 -0.8899107 0
+      vertex -0.95613575 -1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.94765854 -0.8899107 0
+      vertex -1.0934525 -1.0268202 0
+      vertex -1.0517216 -0.7641201 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2135248 -0.8816776 0
+      vertex -1.0517216 -0.7641201 0
+      vertex -1.0934525 -1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0517216 -0.7641201 0
+      vertex -1.2135248 -0.8816776 0
+      vertex -1.1391983 -0.6262789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3144598 -0.7226305 0
+      vertex -1.1391983 -0.6262789 0
+      vertex -1.2135248 -0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.1391983 -0.6262789 0
+      vertex -1.3144598 -0.7226305 0
+      vertex -1.2087088 -0.4785614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3946638 -0.552186 0
+      vertex -1.2087088 -0.4785614 0
+      vertex -1.3144598 -0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4528742 -0.37303448 0
+      vertex -1.2591572 -0.32329655 0
+      vertex -1.3946638 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2087088 -0.4785614 0
+      vertex -1.3946638 -0.552186 0
+      vertex -1.2591572 -0.32329655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4528742 0.37303448 0
+      vertex 1.2591572 0.32329655 0
+      vertex 1.3946638 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2087088 0.4785614 0
+      vertex 1.3946638 0.552186 0
+      vertex 1.2591572 0.32329655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3946638 0.552186 0
+      vertex 1.2087088 0.4785614 0
+      vertex 1.3144598 0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.1391983 0.6262789 0
+      vertex 1.3144598 0.7226305 0
+      vertex 1.2087088 0.4785614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3144598 0.7226305 0
+      vertex 1.1391983 0.6262789 0
+      vertex 1.2135248 0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0517216 0.7641201 0
+      vertex 1.2135248 0.8816776 0
+      vertex 1.1391983 0.6262789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.2135248 0.8816776 0
+      vertex 1.0517216 0.7641201 0
+      vertex 1.0934525 1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.94765854 0.8899107 0
+      vertex 1.0934525 1.0268202 0
+      vertex 1.0517216 0.7641201 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0934525 1.0268202 0
+      vertex 0.94765854 0.8899107 0
+      vertex 0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.8286505 1.001667 0
+      vertex 0.95613575 1.1557693 0
+      vertex 0.94765854 0.8899107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.8286505 1.001667 0
+      vertex 0.80373955 1.2664909 0
+      vertex 0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.6965742 1.0976257 0
+      vertex 0.80373955 1.2664909 0
+      vertex 0.8286505 1.001667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.6965742 1.0976257 0
+      vertex 0.63866806 1.3572397 0
+      vertex 0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5535126 1.1762743 0
+      vertex 0.63866806 1.3572397 0
+      vertex 0.6965742 1.0976257 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5535126 1.1762743 0
+      vertex 0.46352482 1.4265842 0
+      vertex 0.63866806 1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.40172195 1.236373 0
+      vertex 0.46352482 1.4265842 0
+      vertex 0.5535126 1.1762743 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.40172195 1.236373 0
+      vertex 0.28107166 1.4734306 0
+      vertex 0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.24359512 1.2769728 0
+      vertex 0.28107166 1.4734306 0
+      vertex 0.40172195 1.236373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.24359512 1.2769728 0
+      vertex 0.094184875 1.4970398 0
+      vertex 0.28107166 1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.08162689 1.2974339 0
+      vertex 0.094184875 1.4970398 0
+      vertex 0.24359512 1.2769728 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.08162689 1.2974339 0
+      vertex 0.094184875 1.4970398 0
+      vertex 0.08162689 1.2974339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.08162689 1.2974339 0
+      vertex -0.094184875 1.4970398 0
+      vertex 0.094184875 1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.24359512 1.2769728 0
+      vertex -0.094184875 1.4970398 0
+      vertex -0.08162689 1.2974339 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.24359512 1.2769728 0
+      vertex -0.28107166 1.4734306 0
+      vertex -0.094184875 1.4970398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.40172195 1.236373 0
+      vertex -0.28107166 1.4734306 0
+      vertex -0.24359512 1.2769728 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.40172195 1.236373 0
+      vertex -0.46352482 1.4265842 0
+      vertex -0.28107166 1.4734306 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.5535126 1.1762743 0
+      vertex -0.46352482 1.4265842 0
+      vertex -0.40172195 1.236373 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.5535126 1.1762743 0
+      vertex -0.63866806 1.3572397 0
+      vertex -0.46352482 1.4265842 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.6965742 1.0976257 0
+      vertex -0.63866806 1.3572397 0
+      vertex -0.5535126 1.1762743 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.6965742 1.0976257 0
+      vertex -0.80373955 1.2664909 0
+      vertex -0.63866806 1.3572397 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.8286505 1.001667 0
+      vertex -0.80373955 1.2664909 0
+      vertex -0.6965742 1.0976257 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.95613575 1.1557693 0
+      vertex -0.8286505 1.001667 0
+      vertex -0.94765854 0.8899107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.8286505 1.001667 0
+      vertex -0.95613575 1.1557693 0
+      vertex -0.80373955 1.2664909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0934525 1.0268202 0
+      vertex -0.94765854 0.8899107 0
+      vertex -1.0517216 0.7641201 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.94765854 0.8899107 0
+      vertex -1.0934525 1.0268202 0
+      vertex -0.95613575 1.1557693 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2135248 0.8816776 0
+      vertex -1.0517216 0.7641201 0
+      vertex -1.1391983 0.6262789 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3144598 0.7226305 0
+      vertex -1.1391983 0.6262789 0
+      vertex -1.2087088 0.4785614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0517216 0.7641201 0
+      vertex -1.2135248 0.8816776 0
+      vertex -1.0934525 1.0268202 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3946638 0.552186 0
+      vertex -1.2087088 0.4785614 0
+      vertex -1.2591572 0.32329655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4528742 0.37303448 0
+      vertex -1.2591572 0.32329655 0
+      vertex -1.2897482 0.1629324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.1391983 0.6262789 0
+      vertex -1.3144598 0.7226305 0
+      vertex -1.2135248 0.8816776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4881716 0.18799973 0
+      vertex -1.2897482 0.1629324 0
+      vertex -1.2999992 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2591572 -0.32329655 0
+      vertex -1.4528742 -0.37303448 0
+      vertex -1.2897482 -0.1629324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4881716 -0.18799973 0
+      vertex -1.2897482 -0.1629324 0
+      vertex -1.4528742 -0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2087088 0.4785614 0
+      vertex -1.3946638 0.552186 0
+      vertex -1.3144598 0.7226305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2897482 -0.1629324 0
+      vertex -1.4881716 -0.18799973 0
+      vertex -1.2999992 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2591572 0.32329655 0
+      vertex -1.4528742 0.37303448 0
+      vertex -1.3946638 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.5 0 0
+      vertex -1.2999992 0 0
+      vertex -1.4881716 -0.18799973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2897482 0.1629324 0
+      vertex -1.4881716 0.18799973 0
+      vertex -1.4528742 0.37303448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.2999992 0 0
+      vertex -1.5 0 0
+      vertex -1.4881716 0.18799973 0
+    endloop
+  endfacet
+  facet normal -0.99802667 -0.06279179 0
+    outer loop
+      vertex 1.2999992 0 0
+      vertex 1.2897482 0.1629324 10
+      vertex 1.2897482 0.1629324 0
+    endloop
+  endfacet
+  facet normal -0.99802667 -0.06279179 0
+    outer loop
+      vertex 1.2897482 0.1629324 10
+      vertex 1.2999992 0 0
+      vertex 1.2999992 0 10
+    endloop
+  endfacet
+  facet normal -0.24868847 -0.9685835 0
+    outer loop
+      vertex 0.24359512 1.2769728 0
+      vertex 0.40172195 1.236373 10
+      vertex 0.24359512 1.2769728 10
+    endloop
+  endfacet
+  facet normal -0.24868847 -0.9685835 0
+    outer loop
+      vertex 0.40172195 1.236373 10
+      vertex 0.24359512 1.2769728 0
+      vertex 0.40172195 1.236373 0
+    endloop
+  endfacet
+  facet normal 0.587784 -0.8090179 0
+    outer loop
+      vertex -0.8286505 1.001667 0
+      vertex -0.6965742 1.0976257 10
+      vertex -0.8286505 1.001667 10
+    endloop
+  endfacet
+  facet normal 0.587784 -0.8090179 0
+    outer loop
+      vertex -0.6965742 1.0976257 10
+      vertex -0.8286505 1.001667 0
+      vertex -0.6965742 1.0976257 0
+    endloop
+  endfacet
+  facet normal -0.587784 -0.8090179 0
+    outer loop
+      vertex 0.6965742 1.0976257 0
+      vertex 0.8286505 1.001667 10
+      vertex 0.6965742 1.0976257 10
+    endloop
+  endfacet
+  facet normal -0.587784 -0.8090179 0
+    outer loop
+      vertex 0.8286505 1.001667 10
+      vertex 0.6965742 1.0976257 0
+      vertex 0.8286505 1.001667 0
+    endloop
+  endfacet
+  facet normal 0.95105684 0.30901593 0
+    outer loop
+      vertex -1.2087088 -0.4785614 10
+      vertex -1.2591572 -0.32329655 0
+      vertex -1.2591572 -0.32329655 10
+    endloop
+  endfacet
+  facet normal 0.95105684 0.30901593 0
+    outer loop
+      vertex -1.2591572 -0.32329655 0
+      vertex -1.2087088 -0.4785614 10
+      vertex -1.2087088 -0.4785614 0
+    endloop
+  endfacet
+  facet normal 0.24868847 -0.9685835 0
+    outer loop
+      vertex -0.40172195 1.236373 0
+      vertex -0.24359512 1.2769728 10
+      vertex -0.40172195 1.236373 10
+    endloop
+  endfacet
+  facet normal 0.24868847 -0.9685835 0
+    outer loop
+      vertex -0.24359512 1.2769728 10
+      vertex -0.40172195 1.236373 0
+      vertex -0.24359512 1.2769728 0
+    endloop
+  endfacet
+  facet normal -0.9048273 -0.42577875 0
+    outer loop
+      vertex 1.2087088 0.4785614 0
+      vertex 1.1391983 0.6262789 10
+      vertex 1.1391983 0.6262789 0
+    endloop
+  endfacet
+  facet normal -0.9048273 -0.42577875 0
+    outer loop
+      vertex 1.1391983 0.6262789 10
+      vertex 1.2087088 0.4785614 0
+      vertex 1.2087088 0.4785614 10
+    endloop
+  endfacet
+  facet normal 0.98228735 0.1873808 0
+    outer loop
+      vertex -1.2591572 -0.32329655 10
+      vertex -1.2897482 -0.1629324 0
+      vertex -1.2897482 -0.1629324 10
+    endloop
+  endfacet
+  facet normal 0.98228735 0.1873808 0
+    outer loop
+      vertex -1.2897482 -0.1629324 0
+      vertex -1.2591572 -0.32329655 10
+      vertex -1.2591572 -0.32329655 0
+    endloop
+  endfacet
+  facet normal -0.99802667 0.06279179 0
+    outer loop
+      vertex 1.2897482 -0.1629324 0
+      vertex 1.2999992 0 10
+      vertex 1.2999992 0 0
+    endloop
+  endfacet
+  facet normal -0.99802667 0.06279179 0
+    outer loop
+      vertex 1.2999992 0 10
+      vertex 1.2897482 -0.1629324 0
+      vertex 1.2897482 -0.1629324 10
+    endloop
+  endfacet
+  facet normal 0.9048273 -0.42577875 0
+    outer loop
+      vertex -1.2087088 0.4785614 10
+      vertex -1.1391983 0.6262789 0
+      vertex -1.1391983 0.6262789 10
+    endloop
+  endfacet
+  facet normal 0.9048273 -0.42577875 0
+    outer loop
+      vertex -1.1391983 0.6262789 0
+      vertex -1.2087088 0.4785614 10
+      vertex -1.2087088 0.4785614 0
+    endloop
+  endfacet
+  facet normal 0.36812714 -0.9297755 0
+    outer loop
+      vertex -0.5535126 1.1762743 0
+      vertex -0.40172195 1.236373 10
+      vertex -0.5535126 1.1762743 10
+    endloop
+  endfacet
+  facet normal 0.36812714 -0.9297755 0
+    outer loop
+      vertex -0.40172195 1.236373 10
+      vertex -0.5535126 1.1762743 0
+      vertex -0.40172195 1.236373 0
+    endloop
+  endfacet
+  facet normal -0.84432787 0.5358269 0
+    outer loop
+      vertex 1.0517216 -0.7641201 0
+      vertex 1.1391983 -0.6262789 10
+      vertex 1.1391983 -0.6262789 0
+    endloop
+  endfacet
+  facet normal -0.84432787 0.5358269 0
+    outer loop
+      vertex 1.1391983 -0.6262789 10
+      vertex 1.0517216 -0.7641201 0
+      vertex 1.0517216 -0.7641201 10
+    endloop
+  endfacet
+  facet normal 0.36812714 0.9297755 0
+    outer loop
+      vertex -0.40172195 -1.236373 0
+      vertex -0.5535126 -1.1762743 10
+      vertex -0.40172195 -1.236373 10
+    endloop
+  endfacet
+  facet normal 0.36812714 0.9297755 0
+    outer loop
+      vertex -0.5535126 -1.1762743 10
+      vertex -0.40172195 -1.236373 0
+      vertex -0.5535126 -1.1762743 0
+    endloop
+  endfacet
+  facet normal 0.99802667 0.06279179 0
+    outer loop
+      vertex -1.2897482 -0.1629324 10
+      vertex -1.2999992 0 0
+      vertex -1.2999992 0 10
+    endloop
+  endfacet
+  facet normal 0.99802667 0.06279179 0
+    outer loop
+      vertex -1.2999992 0 0
+      vertex -1.2897482 -0.1629324 10
+      vertex -1.2897482 -0.1629324 0
+    endloop
+  endfacet
+  facet normal -0.9048273 0.42577875 0
+    outer loop
+      vertex 1.1391983 -0.6262789 0
+      vertex 1.2087088 -0.4785614 10
+      vertex 1.2087088 -0.4785614 0
+    endloop
+  endfacet
+  facet normal -0.9048273 0.42577875 0
+    outer loop
+      vertex 1.2087088 -0.4785614 10
+      vertex 1.1391983 -0.6262789 0
+      vertex 1.1391983 -0.6262789 10
+    endloop
+  endfacet
+  facet normal -0.98228735 -0.1873808 0
+    outer loop
+      vertex 1.2897482 0.1629324 0
+      vertex 1.2591572 0.32329655 10
+      vertex 1.2591572 0.32329655 0
+    endloop
+  endfacet
+  facet normal -0.98228735 -0.1873808 0
+    outer loop
+      vertex 1.2591572 0.32329655 10
+      vertex 1.2897482 0.1629324 0
+      vertex 1.2897482 0.1629324 10
+    endloop
+  endfacet
+  facet normal 0.95105684 -0.30901593 0
+    outer loop
+      vertex -1.2591572 0.32329655 10
+      vertex -1.2087088 0.4785614 0
+      vertex -1.2087088 0.4785614 10
+    endloop
+  endfacet
+  facet normal 0.95105684 -0.30901593 0
+    outer loop
+      vertex -1.2087088 0.4785614 0
+      vertex -1.2591572 0.32329655 10
+      vertex -1.2591572 0.32329655 0
+    endloop
+  endfacet
+  facet normal -0.84432787 -0.5358269 0
+    outer loop
+      vertex 1.1391983 0.6262789 0
+      vertex 1.0517216 0.7641201 10
+      vertex 1.0517216 0.7641201 0
+    endloop
+  endfacet
+  facet normal -0.84432787 -0.5358269 0
+    outer loop
+      vertex 1.0517216 0.7641201 10
+      vertex 1.1391983 0.6262789 0
+      vertex 1.1391983 0.6262789 10
+    endloop
+  endfacet
+  facet normal 0.99802667 -0.06279179 0
+    outer loop
+      vertex -1.2999992 0 10
+      vertex -1.2897482 0.1629324 0
+      vertex -1.2897482 0.1629324 10
+    endloop
+  endfacet
+  facet normal 0.99802667 -0.06279179 0
+    outer loop
+      vertex -1.2897482 0.1629324 0
+      vertex -1.2999992 0 10
+      vertex -1.2999992 0 0
+    endloop
+  endfacet
+  facet normal 0.68454814 0.72896767 0
+    outer loop
+      vertex -0.8286505 -1.001667 0
+      vertex -0.94765854 -0.8899107 10
+      vertex -0.8286505 -1.001667 10
+    endloop
+  endfacet
+  facet normal 0.68454814 0.72896767 0
+    outer loop
+      vertex -0.94765854 -0.8899107 10
+      vertex -0.8286505 -1.001667 0
+      vertex -0.94765854 -0.8899107 0
+    endloop
+  endfacet
+  facet normal 0.12533164 -0.9921149 0
+    outer loop
+      vertex -0.24359512 1.2769728 0
+      vertex -0.08162689 1.2974339 10
+      vertex -0.24359512 1.2769728 10
+    endloop
+  endfacet
+  facet normal 0.12533164 -0.9921149 0
+    outer loop
+      vertex -0.08162689 1.2974339 10
+      vertex -0.24359512 1.2769728 0
+      vertex -0.08162689 1.2974339 0
+    endloop
+  endfacet
+  facet normal -0.68454814 -0.72896767 0
+    outer loop
+      vertex 0.8286505 1.001667 0
+      vertex 0.94765854 0.8899107 10
+      vertex 0.8286505 1.001667 10
+    endloop
+  endfacet
+  facet normal -0.68454814 -0.72896767 0
+    outer loop
+      vertex 0.94765854 0.8899107 10
+      vertex 0.8286505 1.001667 0
+      vertex 0.94765854 0.8899107 0
+    endloop
+  endfacet
+  facet normal 0.68454814 -0.72896767 0
+    outer loop
+      vertex -0.94765854 0.8899107 0
+      vertex -0.8286505 1.001667 10
+      vertex -0.94765854 0.8899107 10
+    endloop
+  endfacet
+  facet normal 0.68454814 -0.72896767 0
+    outer loop
+      vertex -0.8286505 1.001667 10
+      vertex -0.94765854 0.8899107 0
+      vertex -0.8286505 1.001667 0
+    endloop
+  endfacet
+  facet normal 0.84432787 0.5358269 0
+    outer loop
+      vertex -1.0517216 -0.7641201 10
+      vertex -1.1391983 -0.6262789 0
+      vertex -1.1391983 -0.6262789 10
+    endloop
+  endfacet
+  facet normal 0.84432787 0.5358269 0
+    outer loop
+      vertex -1.1391983 -0.6262789 0
+      vertex -1.0517216 -0.7641201 10
+      vertex -1.0517216 -0.7641201 0
+    endloop
+  endfacet
+  facet normal -0.68454814 0.72896767 0
+    outer loop
+      vertex 0.94765854 -0.8899107 0
+      vertex 0.8286505 -1.001667 10
+      vertex 0.94765854 -0.8899107 10
+    endloop
+  endfacet
+  facet normal -0.68454814 0.72896767 0
+    outer loop
+      vertex 0.8286505 -1.001667 10
+      vertex 0.94765854 -0.8899107 0
+      vertex 0.8286505 -1.001667 0
+    endloop
+  endfacet
+  facet normal -0.95105684 0.30901593 0
+    outer loop
+      vertex 1.2087088 -0.4785614 0
+      vertex 1.2591572 -0.32329655 10
+      vertex 1.2591572 -0.32329655 0
+    endloop
+  endfacet
+  facet normal -0.95105684 0.30901593 0
+    outer loop
+      vertex 1.2591572 -0.32329655 10
+      vertex 1.2087088 -0.4785614 0
+      vertex 1.2087088 -0.4785614 10
+    endloop
+  endfacet
+  facet normal -0.77051324 0.637424 0
+    outer loop
+      vertex 0.94765854 -0.8899107 0
+      vertex 1.0517216 -0.7641201 10
+      vertex 1.0517216 -0.7641201 0
+    endloop
+  endfacet
+  facet normal -0.77051324 0.637424 0
+    outer loop
+      vertex 1.0517216 -0.7641201 10
+      vertex 0.94765854 -0.8899107 0
+      vertex 0.94765854 -0.8899107 10
+    endloop
+  endfacet
+  facet normal 0.77051324 0.637424 0
+    outer loop
+      vertex -0.94765854 -0.8899107 10
+      vertex -1.0517216 -0.7641201 0
+      vertex -1.0517216 -0.7641201 10
+    endloop
+  endfacet
+  facet normal 0.77051324 0.637424 0
+    outer loop
+      vertex -1.0517216 -0.7641201 0
+      vertex -0.94765854 -0.8899107 10
+      vertex -0.94765854 -0.8899107 0
+    endloop
+  endfacet
+  facet normal -0.48175257 0.8763073 0
+    outer loop
+      vertex 0.6965742 -1.0976257 0
+      vertex 0.5535126 -1.1762743 10
+      vertex 0.6965742 -1.0976257 10
+    endloop
+  endfacet
+  facet normal -0.48175257 0.8763073 0
+    outer loop
+      vertex 0.5535126 -1.1762743 10
+      vertex 0.6965742 -1.0976257 0
+      vertex 0.5535126 -1.1762743 0
+    endloop
+  endfacet
+  facet normal 0.77051324 -0.637424 0
+    outer loop
+      vertex -1.0517216 0.7641201 10
+      vertex -0.94765854 0.8899107 0
+      vertex -0.94765854 0.8899107 10
+    endloop
+  endfacet
+  facet normal 0.77051324 -0.637424 0
+    outer loop
+      vertex -0.94765854 0.8899107 0
+      vertex -1.0517216 0.7641201 10
+      vertex -1.0517216 0.7641201 0
+    endloop
+  endfacet
+  facet normal -0.36812714 -0.9297755 0
+    outer loop
+      vertex 0.40172195 1.236373 0
+      vertex 0.5535126 1.1762743 10
+      vertex 0.40172195 1.236373 10
+    endloop
+  endfacet
+  facet normal -0.36812714 -0.9297755 0
+    outer loop
+      vertex 0.5535126 1.1762743 10
+      vertex 0.40172195 1.236373 0
+      vertex 0.5535126 1.1762743 0
+    endloop
+  endfacet
+  facet normal -0.12533164 -0.9921149 0
+    outer loop
+      vertex 0.08162689 1.2974339 0
+      vertex 0.24359512 1.2769728 10
+      vertex 0.08162689 1.2974339 10
+    endloop
+  endfacet
+  facet normal -0.12533164 -0.9921149 0
+    outer loop
+      vertex 0.24359512 1.2769728 10
+      vertex 0.08162689 1.2974339 0
+      vertex 0.24359512 1.2769728 0
+    endloop
+  endfacet
+  facet normal 0.24868847 0.9685835 0
+    outer loop
+      vertex -0.24359512 -1.2769728 0
+      vertex -0.40172195 -1.236373 10
+      vertex -0.24359512 -1.2769728 10
+    endloop
+  endfacet
+  facet normal 0.24868847 0.9685835 0
+    outer loop
+      vertex -0.40172195 -1.236373 10
+      vertex -0.24359512 -1.2769728 0
+      vertex -0.40172195 -1.236373 0
+    endloop
+  endfacet
+  facet normal 0.9048273 0.42577875 0
+    outer loop
+      vertex -1.1391983 -0.6262789 10
+      vertex -1.2087088 -0.4785614 0
+      vertex -1.2087088 -0.4785614 10
+    endloop
+  endfacet
+  facet normal 0.9048273 0.42577875 0
+    outer loop
+      vertex -1.2087088 -0.4785614 0
+      vertex -1.1391983 -0.6262789 10
+      vertex -1.1391983 -0.6262789 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.08162689 -1.2974339 0
+      vertex -0.08162689 -1.2974339 10
+      vertex 0.08162689 -1.2974339 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.08162689 -1.2974339 10
+      vertex 0.08162689 -1.2974339 0
+      vertex -0.08162689 -1.2974339 0
+    endloop
+  endfacet
+  facet normal 0.48175257 -0.8763073 0
+    outer loop
+      vertex -0.6965742 1.0976257 0
+      vertex -0.5535126 1.1762743 10
+      vertex -0.6965742 1.0976257 10
+    endloop
+  endfacet
+  facet normal 0.48175257 -0.8763073 0
+    outer loop
+      vertex -0.5535126 1.1762743 10
+      vertex -0.6965742 1.0976257 0
+      vertex -0.5535126 1.1762743 0
+    endloop
+  endfacet
+  facet normal 0.12533164 0.9921149 0
+    outer loop
+      vertex -0.08162689 -1.2974339 0
+      vertex -0.24359512 -1.2769728 10
+      vertex -0.08162689 -1.2974339 10
+    endloop
+  endfacet
+  facet normal 0.12533164 0.9921149 0
+    outer loop
+      vertex -0.24359512 -1.2769728 10
+      vertex -0.08162689 -1.2974339 0
+      vertex -0.24359512 -1.2769728 0
+    endloop
+  endfacet
+  facet normal -0.48175257 -0.8763073 0
+    outer loop
+      vertex 0.5535126 1.1762743 0
+      vertex 0.6965742 1.0976257 10
+      vertex 0.5535126 1.1762743 10
+    endloop
+  endfacet
+  facet normal -0.48175257 -0.8763073 0
+    outer loop
+      vertex 0.6965742 1.0976257 10
+      vertex 0.5535126 1.1762743 0
+      vertex 0.6965742 1.0976257 0
+    endloop
+  endfacet
+  facet normal 0.587784 0.8090179 0
+    outer loop
+      vertex -0.6965742 -1.0976257 0
+      vertex -0.8286505 -1.001667 10
+      vertex -0.6965742 -1.0976257 10
+    endloop
+  endfacet
+  facet normal 0.587784 0.8090179 0
+    outer loop
+      vertex -0.8286505 -1.001667 10
+      vertex -0.6965742 -1.0976257 0
+      vertex -0.8286505 -1.001667 0
+    endloop
+  endfacet
+  facet normal -0.77051324 -0.637424 0
+    outer loop
+      vertex 1.0517216 0.7641201 0
+      vertex 0.94765854 0.8899107 10
+      vertex 0.94765854 0.8899107 0
+    endloop
+  endfacet
+  facet normal -0.77051324 -0.637424 0
+    outer loop
+      vertex 0.94765854 0.8899107 10
+      vertex 1.0517216 0.7641201 0
+      vertex 1.0517216 0.7641201 10
+    endloop
+  endfacet
+  facet normal -0.95105684 -0.30901593 0
+    outer loop
+      vertex 1.2591572 0.32329655 0
+      vertex 1.2087088 0.4785614 10
+      vertex 1.2087088 0.4785614 0
+    endloop
+  endfacet
+  facet normal -0.95105684 -0.30901593 0
+    outer loop
+      vertex 1.2087088 0.4785614 10
+      vertex 1.2591572 0.32329655 0
+      vertex 1.2591572 0.32329655 10
+    endloop
+  endfacet
+  facet normal -0.36812714 0.9297755 0
+    outer loop
+      vertex 0.5535126 -1.1762743 0
+      vertex 0.40172195 -1.236373 10
+      vertex 0.5535126 -1.1762743 10
+    endloop
+  endfacet
+  facet normal -0.36812714 0.9297755 0
+    outer loop
+      vertex 0.40172195 -1.236373 10
+      vertex 0.5535126 -1.1762743 0
+      vertex 0.40172195 -1.236373 0
+    endloop
+  endfacet
+  facet normal -0.24868847 0.9685835 0
+    outer loop
+      vertex 0.40172195 -1.236373 0
+      vertex 0.24359512 -1.2769728 10
+      vertex 0.40172195 -1.236373 10
+    endloop
+  endfacet
+  facet normal -0.24868847 0.9685835 0
+    outer loop
+      vertex 0.24359512 -1.2769728 10
+      vertex 0.40172195 -1.236373 0
+      vertex 0.24359512 -1.2769728 0
+    endloop
+  endfacet
+  facet normal -0.587784 0.8090179 0
+    outer loop
+      vertex 0.8286505 -1.001667 0
+      vertex 0.6965742 -1.0976257 10
+      vertex 0.8286505 -1.001667 10
+    endloop
+  endfacet
+  facet normal -0.587784 0.8090179 0
+    outer loop
+      vertex 0.6965742 -1.0976257 10
+      vertex 0.8286505 -1.001667 0
+      vertex 0.6965742 -1.0976257 0
+    endloop
+  endfacet
+  facet normal 0.98228735 -0.1873808 0
+    outer loop
+      vertex -1.2897482 0.1629324 10
+      vertex -1.2591572 0.32329655 0
+      vertex -1.2591572 0.32329655 10
+    endloop
+  endfacet
+  facet normal 0.98228735 -0.1873808 0
+    outer loop
+      vertex -1.2591572 0.32329655 0
+      vertex -1.2897482 0.1629324 10
+      vertex -1.2897482 0.1629324 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.08162689 1.2974339 0
+      vertex 0.08162689 1.2974339 10
+      vertex -0.08162689 1.2974339 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.08162689 1.2974339 10
+      vertex -0.08162689 1.2974339 0
+      vertex 0.08162689 1.2974339 0
+    endloop
+  endfacet
+  facet normal 0.48175257 0.8763073 0
+    outer loop
+      vertex -0.5535126 -1.1762743 0
+      vertex -0.6965742 -1.0976257 10
+      vertex -0.5535126 -1.1762743 10
+    endloop
+  endfacet
+  facet normal 0.48175257 0.8763073 0
+    outer loop
+      vertex -0.6965742 -1.0976257 10
+      vertex -0.5535126 -1.1762743 0
+      vertex -0.6965742 -1.0976257 0
+    endloop
+  endfacet
+  facet normal 0.84432787 -0.5358269 0
+    outer loop
+      vertex -1.1391983 0.6262789 10
+      vertex -1.0517216 0.7641201 0
+      vertex -1.0517216 0.7641201 10
+    endloop
+  endfacet
+  facet normal 0.84432787 -0.5358269 0
+    outer loop
+      vertex -1.0517216 0.7641201 0
+      vertex -1.1391983 0.6262789 10
+      vertex -1.1391983 0.6262789 0
+    endloop
+  endfacet
+  facet normal -0.12533164 0.9921149 0
+    outer loop
+      vertex 0.24359512 -1.2769728 0
+      vertex 0.08162689 -1.2974339 10
+      vertex 0.24359512 -1.2769728 10
+    endloop
+  endfacet
+  facet normal -0.12533164 0.9921149 0
+    outer loop
+      vertex 0.08162689 -1.2974339 10
+      vertex 0.24359512 -1.2769728 0
+      vertex 0.08162689 -1.2974339 0
+    endloop
+  endfacet
+  facet normal -0.98228735 0.1873808 0
+    outer loop
+      vertex 1.2591572 -0.32329655 0
+      vertex 1.2897482 -0.1629324 10
+      vertex 1.2897482 -0.1629324 0
+    endloop
+  endfacet
+  facet normal -0.98228735 0.1873808 0
+    outer loop
+      vertex 1.2897482 -0.1629324 10
+      vertex 1.2591572 -0.32329655 0
+      vertex 1.2591572 -0.32329655 10
     endloop
   endfacet
 endsolid OpenSCAD_Model

--- a/test_models/testdata/hollow_cylinder/id_wt.stl
+++ b/test_models/testdata/hollow_cylinder/id_wt.stl
@@ -1,2802 +1,2802 @@
 solid OpenSCAD_Model
-  facet normal 0.982288 0.187377 0
-    outer loop
-      vertex 5.45663 0.689332 10
-      vertex 5.32721 1.36779 0
-      vertex 5.32721 1.36779 10
-    endloop
-  endfacet
-  facet normal 0.982288 0.187377 0
-    outer loop
-      vertex 5.32721 1.36779 0
-      vertex 5.45663 0.689332 10
-      vertex 5.45663 0.689332 0
-    endloop
-  endfacet
-  facet normal 0.998027 0.0627918 0
+  facet normal 0.9980267 0.0627908 0
     outer loop
       vertex 5.5 0 10
-      vertex 5.45663 0.689332 0
-      vertex 5.45663 0.689332 10
+      vertex 5.4566307 0.689332 0
+      vertex 5.4566307 0.689332 10
     endloop
   endfacet
-  facet normal 0.998027 0.0627918 0
+  facet normal 0.9980267 0.0627908 0
     outer loop
-      vertex 5.45663 0.689332 0
+      vertex 5.4566307 0.689332 0
       vertex 5.5 0 10
       vertex 5.5 0 0
     endloop
   endfacet
-  facet normal 0.951055 0.309022 0
+  facet normal -0.9980267 -0.0627908 0
     outer loop
-      vertex 5.32721 1.36779 10
-      vertex 5.11377 2.02468 0
-      vertex 5.11377 2.02468 10
+      vertex -5.4566307 -0.689332 0
+      vertex -5.5 0 10
+      vertex -5.5 0 0
     endloop
   endfacet
-  facet normal 0.951055 0.309022 0
+  facet normal -0.9980267 -0.0627908 0
     outer loop
-      vertex 5.11377 2.02468 0
-      vertex 5.32721 1.36779 10
-      vertex 5.32721 1.36779 0
+      vertex -5.5 0 10
+      vertex -5.4566307 -0.689332 0
+      vertex -5.4566307 -0.689332 10
     endloop
   endfacet
-  facet normal 0.951055 -0.309022 0
+  facet normal -0.6845472 0.72896856 0
     outer loop
-      vertex 5.11377 -2.02468 10
-      vertex 5.32721 -1.36779 0
-      vertex 5.32721 -1.36779 10
+      vertex -3.5058317 4.2378225 0
+      vertex -4.009327 3.765009 10
+      vertex -3.5058317 4.2378225 10
     endloop
   endfacet
-  facet normal 0.951055 -0.309022 0
+  facet normal -0.6845472 0.72896856 0
     outer loop
-      vertex 5.32721 -1.36779 0
-      vertex 5.11377 -2.02468 10
-      vertex 5.11377 -2.02468 0
+      vertex -4.009327 3.765009 10
+      vertex -3.5058317 4.2378225 0
+      vertex -4.009327 3.765009 0
     endloop
   endfacet
-  facet normal 0.368118 0.929779 -0
+  facet normal 0.9822871 0.18738207 0
     outer loop
-      vertex 2.34179 4.97655 0
-      vertex 1.69959 5.23081 10
-      vertex 2.34179 4.97655 10
+      vertex 5.4566307 0.689332 10
+      vertex 5.3272066 1.367794 0
+      vertex 5.3272066 1.367794 10
     endloop
   endfacet
-  facet normal 0.368118 0.929779 0
+  facet normal 0.9822871 0.18738207 0
     outer loop
-      vertex 1.69959 5.23081 10
-      vertex 2.34179 4.97655 0
-      vertex 1.69959 5.23081 0
-    endloop
-  endfacet
-  facet normal -0.587788 -0.809015 0
-    outer loop
-      vertex -3.50583 -4.23782 0
-      vertex -2.94705 -4.6438 10
-      vertex -3.50583 -4.23782 10
-    endloop
-  endfacet
-  facet normal -0.587788 -0.809015 -0
-    outer loop
-      vertex -2.94705 -4.6438 10
-      vertex -3.50583 -4.23782 0
-      vertex -2.94705 -4.6438 0
-    endloop
-  endfacet
-  facet normal -0.684541 -0.728974 0
-    outer loop
-      vertex -4.00933 -3.76501 0
-      vertex -3.50583 -4.23782 10
-      vertex -4.00933 -3.76501 10
-    endloop
-  endfacet
-  facet normal -0.684541 -0.728974 -0
-    outer loop
-      vertex -3.50583 -4.23782 10
-      vertex -4.00933 -3.76501 0
-      vertex -3.50583 -4.23782 0
-    endloop
-  endfacet
-  facet normal 0.998027 -0.0627918 0
-    outer loop
-      vertex 5.45663 -0.689332 10
-      vertex 5.5 0 0
-      vertex 5.5 0 10
-    endloop
-  endfacet
-  facet normal 0.998027 -0.0627918 0
-    outer loop
-      vertex 5.5 0 0
-      vertex 5.45663 -0.689332 10
-      vertex 5.45663 -0.689332 0
-    endloop
-  endfacet
-  facet normal 0.904829 0.425775 0
-    outer loop
-      vertex 5.11377 2.02468 10
-      vertex 4.81969 2.64964 0
-      vertex 4.81969 2.64964 10
-    endloop
-  endfacet
-  facet normal 0.904829 0.425775 0
-    outer loop
-      vertex 4.81969 2.64964 0
-      vertex 5.11377 2.02468 10
-      vertex 5.11377 2.02468 0
-    endloop
-  endfacet
-  facet normal -0.125337 0.992114 0
-    outer loop
-      vertex -0.345347 5.48915 0
-      vertex -1.0306 5.40258 10
-      vertex -0.345347 5.48915 10
-    endloop
-  endfacet
-  facet normal -0.125337 0.992114 0
-    outer loop
-      vertex -1.0306 5.40258 10
-      vertex -0.345347 5.48915 0
-      vertex -1.0306 5.40258 0
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.345347 5.48915 0
-      vertex -0.345347 5.48915 10
-      vertex 0.345347 5.48915 10
+      vertex 5.3272066 1.367794 0
+      vertex 5.4566307 0.689332 10
+      vertex 5.4566307 0.689332 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.345347 5.48915 10
-      vertex 0.345347 5.48915 0
-      vertex -0.345347 5.48915 0
-    endloop
-  endfacet
-  facet normal 0.844326 0.53583 0
-    outer loop
-      vertex 4.81969 2.64964 10
-      vertex 4.44959 3.23282 0
-      vertex 4.44959 3.23282 10
-    endloop
-  endfacet
-  facet normal 0.844326 0.53583 0
-    outer loop
-      vertex 4.44959 3.23282 0
-      vertex 4.81969 2.64964 10
-      vertex 4.81969 2.64964 0
-    endloop
-  endfacet
-  facet normal -0.368118 -0.929779 0
-    outer loop
-      vertex -2.34179 -4.97655 0
-      vertex -1.69959 -5.23081 10
-      vertex -2.34179 -4.97655 10
-    endloop
-  endfacet
-  facet normal -0.368118 -0.929779 -0
-    outer loop
-      vertex -1.69959 -5.23081 10
-      vertex -2.34179 -4.97655 0
-      vertex -1.69959 -5.23081 0
-    endloop
-  endfacet
-  facet normal 0.587788 -0.809015 0
-    outer loop
-      vertex 2.94705 -4.6438 0
-      vertex 3.50583 -4.23782 10
-      vertex 2.94705 -4.6438 10
-    endloop
-  endfacet
-  facet normal 0.587788 -0.809015 0
-    outer loop
-      vertex 3.50583 -4.23782 10
-      vertex 2.94705 -4.6438 0
-      vertex 3.50583 -4.23782 0
-    endloop
-  endfacet
-  facet normal -0.982288 -0.187377 0
-    outer loop
-      vertex -5.32721 -1.36779 0
-      vertex -5.45663 -0.689332 10
-      vertex -5.45663 -0.689332 0
-    endloop
-  endfacet
-  facet normal -0.982288 -0.187377 0
-    outer loop
-      vertex -5.45663 -0.689332 10
-      vertex -5.32721 -1.36779 0
-      vertex -5.32721 -1.36779 10
-    endloop
-  endfacet
-  facet normal -0.770517 -0.637419 0
-    outer loop
-      vertex -4.00933 -3.76501 0
-      vertex -4.44959 -3.23282 10
-      vertex -4.44959 -3.23282 0
-    endloop
-  endfacet
-  facet normal -0.770517 -0.637419 0
-    outer loop
-      vertex -4.44959 -3.23282 10
-      vertex -4.00933 -3.76501 0
-      vertex -4.00933 -3.76501 10
-    endloop
-  endfacet
-  facet normal -0.48176 0.876303 0
-    outer loop
-      vertex -2.34179 4.97655 0
-      vertex -2.94705 4.6438 10
-      vertex -2.34179 4.97655 10
-    endloop
-  endfacet
-  facet normal -0.48176 0.876303 0
-    outer loop
-      vertex -2.94705 4.6438 10
-      vertex -2.34179 4.97655 0
-      vertex -2.94705 4.6438 0
-    endloop
-  endfacet
-  facet normal 0.982288 -0.187377 0
-    outer loop
-      vertex 5.32721 -1.36779 10
-      vertex 5.45663 -0.689332 0
-      vertex 5.45663 -0.689332 10
-    endloop
-  endfacet
-  facet normal 0.982288 -0.187377 0
-    outer loop
-      vertex 5.45663 -0.689332 0
-      vertex 5.32721 -1.36779 10
-      vertex 5.32721 -1.36779 0
-    endloop
-  endfacet
-  facet normal 0.48176 -0.876303 0
-    outer loop
-      vertex 2.34179 -4.97655 0
-      vertex 2.94705 -4.6438 10
-      vertex 2.34179 -4.97655 10
-    endloop
-  endfacet
-  facet normal 0.48176 -0.876303 0
-    outer loop
-      vertex 2.94705 -4.6438 10
-      vertex 2.34179 -4.97655 0
-      vertex 2.94705 -4.6438 0
-    endloop
-  endfacet
-  facet normal -0.684541 0.728974 0
-    outer loop
-      vertex -3.50583 4.23782 0
-      vertex -4.00933 3.76501 10
-      vertex -3.50583 4.23782 10
-    endloop
-  endfacet
-  facet normal -0.684541 0.728974 0
-    outer loop
-      vertex -4.00933 3.76501 10
-      vertex -3.50583 4.23782 0
-      vertex -4.00933 3.76501 0
-    endloop
-  endfacet
-  facet normal 0.368118 -0.929779 0
-    outer loop
-      vertex 1.69959 -5.23081 0
-      vertex 2.34179 -4.97655 10
-      vertex 1.69959 -5.23081 10
-    endloop
-  endfacet
-  facet normal 0.368118 -0.929779 0
-    outer loop
-      vertex 2.34179 -4.97655 10
-      vertex 1.69959 -5.23081 0
-      vertex 2.34179 -4.97655 0
-    endloop
-  endfacet
-  facet normal 0.248693 -0.968582 0
-    outer loop
-      vertex 1.0306 -5.40258 0
-      vertex 1.69959 -5.23081 10
-      vertex 1.0306 -5.40258 10
-    endloop
-  endfacet
-  facet normal 0.248693 -0.968582 0
-    outer loop
-      vertex 1.69959 -5.23081 10
-      vertex 1.0306 -5.40258 0
-      vertex 1.69959 -5.23081 0
-    endloop
-  endfacet
-  facet normal 0.48176 0.876303 -0
-    outer loop
-      vertex 2.94705 4.6438 0
-      vertex 2.34179 4.97655 10
-      vertex 2.94705 4.6438 10
-    endloop
-  endfacet
-  facet normal 0.48176 0.876303 0
-    outer loop
-      vertex 2.34179 4.97655 10
-      vertex 2.94705 4.6438 0
-      vertex 2.34179 4.97655 0
-    endloop
-  endfacet
-  facet normal 0.587788 0.809015 -0
-    outer loop
-      vertex 3.50583 4.23782 0
-      vertex 2.94705 4.6438 10
-      vertex 3.50583 4.23782 10
-    endloop
-  endfacet
-  facet normal 0.587788 0.809015 0
-    outer loop
-      vertex 2.94705 4.6438 10
-      vertex 3.50583 4.23782 0
-      vertex 2.94705 4.6438 0
-    endloop
-  endfacet
-  facet normal -0.998027 -0.0627918 0
-    outer loop
-      vertex -5.45663 -0.689332 0
-      vertex -5.5 0 10
-      vertex -5.5 0 0
-    endloop
-  endfacet
-  facet normal -0.998027 -0.0627918 0
-    outer loop
-      vertex -5.5 0 10
-      vertex -5.45663 -0.689332 0
-      vertex -5.45663 -0.689332 10
-    endloop
-  endfacet
-  facet normal -0.844326 -0.53583 0
-    outer loop
-      vertex -4.44959 -3.23282 0
-      vertex -4.81969 -2.64964 10
-      vertex -4.81969 -2.64964 0
-    endloop
-  endfacet
-  facet normal -0.844326 -0.53583 0
-    outer loop
-      vertex -4.81969 -2.64964 10
-      vertex -4.44959 -3.23282 0
-      vertex -4.44959 -3.23282 10
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.5 0 0
-      vertex 5.5 0 0
-      vertex 5.45663 -0.689332 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.48029 -0.313333 0
-      vertex 5.45663 -0.689332 0
-      vertex 5.32721 -1.36779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.5 0 0
-      vertex 2.5 0 0
-      vertex 5.45663 0.689332 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.42146 -0.621724 0
-      vertex 5.32721 -1.36779 0
-      vertex 5.11377 -2.02468 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.48029 0.313333 0
-      vertex 5.45663 0.689332 0
-      vertex 2.5 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.32444 -0.920311 0
-      vertex 5.11377 -2.02468 0
-      vertex 4.81969 -2.64964 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 5.45663 0.689332 0
-      vertex 2.48029 0.313333 0
-      vertex 5.32721 1.36779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.19077 -1.20438 0
-      vertex 4.81969 -2.64964 0
-      vertex 4.44959 -3.23282 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.42146 0.621724 0
-      vertex 5.32721 1.36779 0
-      vertex 2.48029 0.313333 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.02254 -1.46946 0
-      vertex 4.44959 -3.23282 0
-      vertex 4.00933 -3.76501 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 5.32721 1.36779 0
-      vertex 2.42146 0.621724 0
-      vertex 5.11377 2.02468 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.82242 -1.71137 0
-      vertex 4.00933 -3.76501 0
-      vertex 3.50583 -4.23782 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.32444 0.920311 0
-      vertex 5.11377 2.02468 0
-      vertex 2.42146 0.621724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.59356 -1.92628 0
-      vertex 3.50583 -4.23782 0
-      vertex 2.94705 -4.6438 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 5.11377 2.02468 0
-      vertex 2.32444 0.920311 0
-      vertex 4.81969 2.64964 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.19077 1.20438 0
-      vertex 4.81969 2.64964 0
-      vertex 2.32444 0.920311 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.45663 -0.689332 0
-      vertex 2.48029 -0.313333 0
-      vertex 2.5 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.32721 -1.36779 0
-      vertex 2.42146 -0.621724 0
-      vertex 2.48029 -0.313333 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.33957 -2.11082 0
-      vertex 2.94705 -4.6438 0
-      vertex 2.34179 -4.97655 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.11377 -2.02468 0
-      vertex 2.32444 -0.920311 0
-      vertex 2.42146 -0.621724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 4.81969 -2.64964 0
-      vertex 2.19077 -1.20438 0
-      vertex 2.32444 -0.920311 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 4.44959 -3.23282 0
-      vertex 2.02254 -1.46946 0
-      vertex 2.19077 -1.20438 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 4.00933 -3.76501 0
-      vertex 1.82242 -1.71137 0
-      vertex 2.02254 -1.46946 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.06445 -2.26207 0
-      vertex 2.34179 -4.97655 0
-      vertex 1.69959 -5.23081 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3.50583 -4.23782 0
-      vertex 1.59356 -1.92628 0
-      vertex 1.82242 -1.71137 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.94705 -4.6438 0
-      vertex 1.33957 -2.11082 0
-      vertex 1.59356 -1.92628 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.34179 -4.97655 0
-      vertex 1.06445 -2.26207 0
-      vertex 1.33957 -2.11082 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.772542 -2.37764 0
-      vertex 1.69959 -5.23081 0
-      vertex 1.0306 -5.40258 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.69959 -5.23081 0
-      vertex 0.772542 -2.37764 0
-      vertex 1.06445 -2.26207 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.0306 -5.40258 0
-      vertex 0.468452 -2.45572 0
-      vertex 0.772542 -2.37764 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.345347 -5.48915 0
-      vertex 0.468452 -2.45572 0
-      vertex 1.0306 -5.40258 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.345347 -5.48915 0
-      vertex 0.156976 -2.49507 0
-      vertex 0.468452 -2.45572 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.345347 -5.48915 0
-      vertex -0.156976 -2.49507 0
-      vertex 0.156976 -2.49507 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.345347 -5.48915 0
-      vertex -0.156976 -2.49507 0
-      vertex 0.345347 -5.48915 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.345347 -5.48915 0
-      vertex -0.468452 -2.45572 0
-      vertex -0.156976 -2.49507 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.0306 -5.40258 0
-      vertex -0.468452 -2.45572 0
-      vertex -0.345347 -5.48915 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.468452 -2.45572 0
-      vertex -1.0306 -5.40258 0
-      vertex -0.772542 -2.37764 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.69959 -5.23081 0
-      vertex -0.772542 -2.37764 0
-      vertex -1.0306 -5.40258 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.772542 -2.37764 0
-      vertex -1.69959 -5.23081 0
-      vertex -1.06445 -2.26207 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.34179 -4.97655 0
-      vertex -1.06445 -2.26207 0
-      vertex -1.69959 -5.23081 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.06445 -2.26207 0
-      vertex -2.34179 -4.97655 0
-      vertex -1.33957 -2.11082 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.94705 -4.6438 0
-      vertex -1.33957 -2.11082 0
-      vertex -2.34179 -4.97655 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.33957 -2.11082 0
-      vertex -2.94705 -4.6438 0
-      vertex -1.59356 -1.92628 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3.50583 -4.23782 0
-      vertex -1.59356 -1.92628 0
-      vertex -2.94705 -4.6438 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.59356 -1.92628 0
-      vertex -3.50583 -4.23782 0
-      vertex -1.82242 -1.71137 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.00933 -3.76501 0
-      vertex -1.82242 -1.71137 0
-      vertex -3.50583 -4.23782 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.82242 -1.71137 0
-      vertex -4.00933 -3.76501 0
-      vertex -2.02254 -1.46946 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.44959 -3.23282 0
-      vertex -2.02254 -1.46946 0
-      vertex -4.00933 -3.76501 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.02254 -1.46946 0
-      vertex -4.44959 -3.23282 0
-      vertex -2.19077 -1.20438 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.81969 -2.64964 0
-      vertex -2.19077 -1.20438 0
-      vertex -4.44959 -3.23282 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 4.81969 2.64964 0
-      vertex 2.19077 1.20438 0
-      vertex 4.44959 3.23282 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.02254 1.46946 0
-      vertex 4.44959 3.23282 0
-      vertex 2.19077 1.20438 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 4.44959 3.23282 0
-      vertex 2.02254 1.46946 0
-      vertex 4.00933 3.76501 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.82242 1.71137 0
-      vertex 4.00933 3.76501 0
-      vertex 2.02254 1.46946 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 4.00933 3.76501 0
-      vertex 1.82242 1.71137 0
-      vertex 3.50583 4.23782 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.59356 1.92628 0
-      vertex 3.50583 4.23782 0
-      vertex 1.82242 1.71137 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 3.50583 4.23782 0
-      vertex 1.59356 1.92628 0
-      vertex 2.94705 4.6438 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.33957 2.11082 0
-      vertex 2.94705 4.6438 0
-      vertex 1.59356 1.92628 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 2.94705 4.6438 0
-      vertex 1.33957 2.11082 0
-      vertex 2.34179 4.97655 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.06445 2.26207 0
-      vertex 2.34179 4.97655 0
-      vertex 1.33957 2.11082 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 2.34179 4.97655 0
-      vertex 1.06445 2.26207 0
-      vertex 1.69959 5.23081 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.772542 2.37764 0
-      vertex 1.69959 5.23081 0
-      vertex 1.06445 2.26207 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.69959 5.23081 0
-      vertex 0.772542 2.37764 0
-      vertex 1.0306 5.40258 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.468452 2.45572 0
-      vertex 1.0306 5.40258 0
-      vertex 0.772542 2.37764 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.468452 2.45572 0
-      vertex 0.345347 5.48915 0
-      vertex 1.0306 5.40258 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.156976 2.49507 0
-      vertex 0.345347 5.48915 0
-      vertex 0.468452 2.45572 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.156976 2.49507 0
-      vertex 0.345347 5.48915 0
-      vertex 0.156976 2.49507 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.156976 2.49507 0
-      vertex -0.345347 5.48915 0
-      vertex 0.345347 5.48915 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.468452 2.45572 0
-      vertex -0.345347 5.48915 0
-      vertex -0.156976 2.49507 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.0306 5.40258 0
-      vertex -0.468452 2.45572 0
-      vertex -0.772542 2.37764 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.468452 2.45572 0
-      vertex -1.0306 5.40258 0
-      vertex -0.345347 5.48915 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.69959 5.23081 0
-      vertex -0.772542 2.37764 0
-      vertex -1.06445 2.26207 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.34179 4.97655 0
-      vertex -1.06445 2.26207 0
-      vertex -1.33957 2.11082 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.94705 4.6438 0
-      vertex -1.33957 2.11082 0
-      vertex -1.59356 1.92628 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.772542 2.37764 0
-      vertex -1.69959 5.23081 0
-      vertex -1.0306 5.40258 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3.50583 4.23782 0
-      vertex -1.59356 1.92628 0
-      vertex -1.82242 1.71137 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.00933 3.76501 0
-      vertex -1.82242 1.71137 0
-      vertex -2.02254 1.46946 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.44959 3.23282 0
-      vertex -2.02254 1.46946 0
-      vertex -2.19077 1.20438 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.81969 2.64964 0
-      vertex -2.19077 1.20438 0
-      vertex -2.32444 0.920311 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.06445 2.26207 0
-      vertex -2.34179 4.97655 0
-      vertex -1.69959 5.23081 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.11377 2.02468 0
-      vertex -2.32444 0.920311 0
-      vertex -2.42146 0.621724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.32721 1.36779 0
-      vertex -2.42146 0.621724 0
-      vertex -2.48029 0.313333 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.45663 0.689332 0
-      vertex -2.48029 0.313333 0
-      vertex -2.5 0 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.19077 -1.20438 0
-      vertex -4.81969 -2.64964 0
-      vertex -2.32444 -0.920311 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.33957 2.11082 0
-      vertex -2.94705 4.6438 0
-      vertex -2.34179 4.97655 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.11377 -2.02468 0
-      vertex -2.32444 -0.920311 0
-      vertex -4.81969 -2.64964 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.59356 1.92628 0
-      vertex -3.50583 4.23782 0
-      vertex -2.94705 4.6438 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.32444 -0.920311 0
-      vertex -5.11377 -2.02468 0
-      vertex -2.42146 -0.621724 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.82242 1.71137 0
-      vertex -4.00933 3.76501 0
-      vertex -3.50583 4.23782 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.32721 -1.36779 0
-      vertex -2.42146 -0.621724 0
-      vertex -5.11377 -2.02468 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.02254 1.46946 0
-      vertex -4.44959 3.23282 0
-      vertex -4.00933 3.76501 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.42146 -0.621724 0
-      vertex -5.32721 -1.36779 0
-      vertex -2.48029 -0.313333 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.19077 1.20438 0
-      vertex -4.81969 2.64964 0
-      vertex -4.44959 3.23282 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.45663 -0.689332 0
-      vertex -2.48029 -0.313333 0
-      vertex -5.32721 -1.36779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.32444 0.920311 0
-      vertex -5.11377 2.02468 0
-      vertex -4.81969 2.64964 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.48029 -0.313333 0
-      vertex -5.45663 -0.689332 0
-      vertex -2.5 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.42146 0.621724 0
-      vertex -5.32721 1.36779 0
-      vertex -5.11377 2.02468 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.5 0 0
-      vertex -2.5 0 0
-      vertex -5.45663 -0.689332 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.48029 0.313333 0
-      vertex -5.45663 0.689332 0
-      vertex -5.32721 1.36779 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.5 0 0
-      vertex -5.5 0 0
-      vertex -5.45663 0.689332 0
-    endloop
-  endfacet
-  facet normal 0.904829 -0.425775 0
-    outer loop
-      vertex 4.81969 -2.64964 10
-      vertex 5.11377 -2.02468 0
-      vertex 5.11377 -2.02468 10
-    endloop
-  endfacet
-  facet normal 0.904829 -0.425775 0
-    outer loop
-      vertex 5.11377 -2.02468 0
-      vertex 4.81969 -2.64964 10
-      vertex 4.81969 -2.64964 0
-    endloop
-  endfacet
-  facet normal -0.951055 0.309022 0
-    outer loop
-      vertex -5.32721 1.36779 0
-      vertex -5.11377 2.02468 10
-      vertex -5.11377 2.02468 0
-    endloop
-  endfacet
-  facet normal -0.951055 0.309022 0
-    outer loop
-      vertex -5.11377 2.02468 10
-      vertex -5.32721 1.36779 0
-      vertex -5.32721 1.36779 10
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309022 0
-    outer loop
-      vertex -5.11377 -2.02468 0
-      vertex -5.32721 -1.36779 10
-      vertex -5.32721 -1.36779 0
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309022 0
-    outer loop
-      vertex -5.32721 -1.36779 10
-      vertex -5.11377 -2.02468 0
-      vertex -5.11377 -2.02468 10
-    endloop
-  endfacet
-  facet normal 0.684541 0.728974 -0
-    outer loop
-      vertex 4.00933 3.76501 0
-      vertex 3.50583 4.23782 10
-      vertex 4.00933 3.76501 10
-    endloop
-  endfacet
-  facet normal 0.684541 0.728974 0
-    outer loop
-      vertex 3.50583 4.23782 10
-      vertex 4.00933 3.76501 0
-      vertex 3.50583 4.23782 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.345347 -5.48915 0
-      vertex 0.345347 -5.48915 10
-      vertex -0.345347 -5.48915 10
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 0.345347 -5.48915 10
-      vertex -0.345347 -5.48915 0
-      vertex 0.345347 -5.48915 0
-    endloop
-  endfacet
-  facet normal 0.844326 -0.53583 0
-    outer loop
-      vertex 4.44959 -3.23282 10
-      vertex 4.81969 -2.64964 0
-      vertex 4.81969 -2.64964 10
-    endloop
-  endfacet
-  facet normal 0.844326 -0.53583 0
-    outer loop
-      vertex 4.81969 -2.64964 0
-      vertex 4.44959 -3.23282 10
-      vertex 4.44959 -3.23282 0
-    endloop
-  endfacet
-  facet normal 0.125337 -0.992114 0
-    outer loop
-      vertex 0.345347 -5.48915 0
-      vertex 1.0306 -5.40258 10
-      vertex 0.345347 -5.48915 10
-    endloop
-  endfacet
-  facet normal 0.125337 -0.992114 0
-    outer loop
-      vertex 1.0306 -5.40258 10
-      vertex 0.345347 -5.48915 0
-      vertex 1.0306 -5.40258 0
-    endloop
-  endfacet
-  facet normal -0.368118 0.929779 0
-    outer loop
-      vertex -1.69959 5.23081 0
-      vertex -2.34179 4.97655 10
-      vertex -1.69959 5.23081 10
-    endloop
-  endfacet
-  facet normal -0.368118 0.929779 0
-    outer loop
-      vertex -2.34179 4.97655 10
-      vertex -1.69959 5.23081 0
-      vertex -2.34179 4.97655 0
-    endloop
-  endfacet
-  facet normal -0.982288 0.187377 0
-    outer loop
-      vertex -5.45663 0.689332 0
-      vertex -5.32721 1.36779 10
-      vertex -5.32721 1.36779 0
-    endloop
-  endfacet
-  facet normal -0.982288 0.187377 0
-    outer loop
-      vertex -5.32721 1.36779 10
-      vertex -5.45663 0.689332 0
-      vertex -5.45663 0.689332 10
-    endloop
-  endfacet
-  facet normal 0.684541 -0.728974 0
-    outer loop
-      vertex 3.50583 -4.23782 0
-      vertex 4.00933 -3.76501 10
-      vertex 3.50583 -4.23782 10
-    endloop
-  endfacet
-  facet normal 0.684541 -0.728974 0
-    outer loop
-      vertex 4.00933 -3.76501 10
-      vertex 3.50583 -4.23782 0
-      vertex 4.00933 -3.76501 0
-    endloop
-  endfacet
-  facet normal -0.587788 0.809015 0
-    outer loop
-      vertex -2.94705 4.6438 0
-      vertex -3.50583 4.23782 10
-      vertex -2.94705 4.6438 10
-    endloop
-  endfacet
-  facet normal -0.587788 0.809015 0
-    outer loop
-      vertex -3.50583 4.23782 10
-      vertex -2.94705 4.6438 0
-      vertex -3.50583 4.23782 0
-    endloop
-  endfacet
-  facet normal -0.248693 -0.968582 0
-    outer loop
-      vertex -1.69959 -5.23081 0
-      vertex -1.0306 -5.40258 10
-      vertex -1.69959 -5.23081 10
-    endloop
-  endfacet
-  facet normal -0.248693 -0.968582 -0
-    outer loop
-      vertex -1.0306 -5.40258 10
-      vertex -1.69959 -5.23081 0
-      vertex -1.0306 -5.40258 0
-    endloop
-  endfacet
-  facet normal -0.125337 -0.992114 0
-    outer loop
-      vertex -1.0306 -5.40258 0
-      vertex -0.345347 -5.48915 10
-      vertex -1.0306 -5.40258 10
-    endloop
-  endfacet
-  facet normal -0.125337 -0.992114 -0
-    outer loop
-      vertex -0.345347 -5.48915 10
-      vertex -1.0306 -5.40258 0
-      vertex -0.345347 -5.48915 0
-    endloop
-  endfacet
-  facet normal 0.770517 0.637419 0
-    outer loop
-      vertex 4.44959 3.23282 10
-      vertex 4.00933 3.76501 0
-      vertex 4.00933 3.76501 10
-    endloop
-  endfacet
-  facet normal 0.770517 0.637419 0
-    outer loop
-      vertex 4.00933 3.76501 0
-      vertex 4.44959 3.23282 10
-      vertex 4.44959 3.23282 0
-    endloop
-  endfacet
-  facet normal 0.248693 0.968582 -0
-    outer loop
-      vertex 1.69959 5.23081 0
-      vertex 1.0306 5.40258 10
-      vertex 1.69959 5.23081 10
-    endloop
-  endfacet
-  facet normal 0.248693 0.968582 0
-    outer loop
-      vertex 1.0306 5.40258 10
-      vertex 1.69959 5.23081 0
-      vertex 1.0306 5.40258 0
-    endloop
-  endfacet
-  facet normal 0.125337 0.992114 -0
-    outer loop
-      vertex 1.0306 5.40258 0
-      vertex 0.345347 5.48915 10
-      vertex 1.0306 5.40258 10
-    endloop
-  endfacet
-  facet normal 0.125337 0.992114 0
-    outer loop
-      vertex 0.345347 5.48915 10
-      vertex 1.0306 5.40258 0
-      vertex 0.345347 5.48915 0
-    endloop
-  endfacet
-  facet normal -0.248693 0.968582 0
-    outer loop
-      vertex -1.0306 5.40258 0
-      vertex -1.69959 5.23081 10
-      vertex -1.0306 5.40258 10
-    endloop
-  endfacet
-  facet normal -0.248693 0.968582 0
-    outer loop
-      vertex -1.69959 5.23081 10
-      vertex -1.0306 5.40258 0
-      vertex -1.69959 5.23081 0
-    endloop
-  endfacet
-  facet normal -0.998027 0.0627918 0
-    outer loop
-      vertex -5.5 0 0
-      vertex -5.45663 0.689332 10
-      vertex -5.45663 0.689332 0
-    endloop
-  endfacet
-  facet normal -0.998027 0.0627918 0
-    outer loop
-      vertex -5.45663 0.689332 10
-      vertex -5.5 0 0
-      vertex -5.5 0 10
-    endloop
-  endfacet
-  facet normal 0.770517 -0.637419 0
-    outer loop
-      vertex 4.00933 -3.76501 10
-      vertex 4.44959 -3.23282 0
-      vertex 4.44959 -3.23282 10
-    endloop
-  endfacet
-  facet normal 0.770517 -0.637419 0
-    outer loop
-      vertex 4.44959 -3.23282 0
-      vertex 4.00933 -3.76501 10
-      vertex 4.00933 -3.76501 0
-    endloop
-  endfacet
-  facet normal -0.770517 0.637419 0
-    outer loop
-      vertex -4.44959 3.23282 0
-      vertex -4.00933 3.76501 10
-      vertex -4.00933 3.76501 0
-    endloop
-  endfacet
-  facet normal -0.770517 0.637419 0
-    outer loop
-      vertex -4.00933 3.76501 10
-      vertex -4.44959 3.23282 0
-      vertex -4.44959 3.23282 10
-    endloop
-  endfacet
-  facet normal -0.904829 -0.425775 0
-    outer loop
-      vertex -4.81969 -2.64964 0
-      vertex -5.11377 -2.02468 10
-      vertex -5.11377 -2.02468 0
-    endloop
-  endfacet
-  facet normal -0.904829 -0.425775 0
-    outer loop
-      vertex -5.11377 -2.02468 10
-      vertex -4.81969 -2.64964 0
-      vertex -4.81969 -2.64964 10
-    endloop
-  endfacet
-  facet normal -0.48176 -0.876303 0
-    outer loop
-      vertex -2.94705 -4.6438 0
-      vertex -2.34179 -4.97655 10
-      vertex -2.94705 -4.6438 10
-    endloop
-  endfacet
-  facet normal -0.48176 -0.876303 -0
-    outer loop
-      vertex -2.34179 -4.97655 10
-      vertex -2.94705 -4.6438 0
-      vertex -2.34179 -4.97655 0
-    endloop
-  endfacet
-  facet normal -0.844326 0.53583 0
-    outer loop
-      vertex -4.81969 2.64964 0
-      vertex -4.44959 3.23282 10
-      vertex -4.44959 3.23282 0
-    endloop
-  endfacet
-  facet normal -0.844326 0.53583 0
-    outer loop
-      vertex -4.44959 3.23282 10
-      vertex -4.81969 2.64964 0
-      vertex -4.81969 2.64964 10
-    endloop
-  endfacet
-  facet normal -0.904829 0.425775 0
-    outer loop
-      vertex -5.11377 2.02468 0
-      vertex -4.81969 2.64964 10
-      vertex -4.81969 2.64964 0
-    endloop
-  endfacet
-  facet normal -0.904829 0.425775 0
-    outer loop
-      vertex -4.81969 2.64964 10
-      vertex -5.11377 2.02468 0
-      vertex -5.11377 2.02468 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.5 0 10
-      vertex 5.5 0 10
-      vertex 5.45663 0.689332 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.48029 0.313333 10
-      vertex 5.45663 0.689332 10
-      vertex 5.32721 1.36779 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.5 0 10
-      vertex 2.5 0 10
-      vertex 5.45663 -0.689332 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.42146 0.621724 10
-      vertex 5.32721 1.36779 10
-      vertex 5.11377 2.02468 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.48029 -0.313333 10
-      vertex 5.45663 -0.689332 10
-      vertex 2.5 0 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.32444 0.920311 10
-      vertex 5.11377 2.02468 10
-      vertex 4.81969 2.64964 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.45663 -0.689332 10
-      vertex 2.48029 -0.313333 10
-      vertex 5.32721 -1.36779 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.19077 1.20438 10
-      vertex 4.81969 2.64964 10
-      vertex 4.44959 3.23282 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.42146 -0.621724 10
-      vertex 5.32721 -1.36779 10
-      vertex 2.48029 -0.313333 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.02254 1.46946 10
-      vertex 4.44959 3.23282 10
-      vertex 4.00933 3.76501 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.32721 -1.36779 10
-      vertex 2.42146 -0.621724 10
-      vertex 5.11377 -2.02468 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.82242 1.71137 10
-      vertex 4.00933 3.76501 10
-      vertex 3.50583 4.23782 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.32444 -0.920311 10
-      vertex 5.11377 -2.02468 10
-      vertex 2.42146 -0.621724 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.59356 1.92628 10
-      vertex 3.50583 4.23782 10
-      vertex 2.94705 4.6438 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.11377 -2.02468 10
-      vertex 2.32444 -0.920311 10
-      vertex 4.81969 -2.64964 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.19077 -1.20438 10
-      vertex 4.81969 -2.64964 10
-      vertex 2.32444 -0.920311 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.45663 0.689332 10
-      vertex 2.48029 0.313333 10
-      vertex 2.5 0 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.32721 1.36779 10
-      vertex 2.42146 0.621724 10
-      vertex 2.48029 0.313333 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.33957 2.11082 10
-      vertex 2.94705 4.6438 10
-      vertex 2.34179 4.97655 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.11377 2.02468 10
-      vertex 2.32444 0.920311 10
-      vertex 2.42146 0.621724 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.81969 2.64964 10
-      vertex 2.19077 1.20438 10
-      vertex 2.32444 0.920311 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.44959 3.23282 10
-      vertex 2.02254 1.46946 10
-      vertex 2.19077 1.20438 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.00933 3.76501 10
-      vertex 1.82242 1.71137 10
-      vertex 2.02254 1.46946 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.06445 2.26207 10
-      vertex 2.34179 4.97655 10
-      vertex 1.69959 5.23081 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.50583 4.23782 10
-      vertex 1.59356 1.92628 10
-      vertex 1.82242 1.71137 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.94705 4.6438 10
-      vertex 1.33957 2.11082 10
-      vertex 1.59356 1.92628 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.34179 4.97655 10
-      vertex 1.06445 2.26207 10
-      vertex 1.33957 2.11082 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.772542 2.37764 10
-      vertex 1.69959 5.23081 10
-      vertex 1.0306 5.40258 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.69959 5.23081 10
-      vertex 0.772542 2.37764 10
-      vertex 1.06445 2.26207 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.0306 5.40258 10
-      vertex 0.468452 2.45572 10
-      vertex 0.772542 2.37764 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.345347 5.48915 10
-      vertex 0.468452 2.45572 10
-      vertex 1.0306 5.40258 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.345347 5.48915 10
-      vertex 0.156976 2.49507 10
-      vertex 0.468452 2.45572 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.345347 5.48915 10
-      vertex -0.156976 2.49507 10
-      vertex 0.156976 2.49507 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.345347 5.48915 10
-      vertex -0.156976 2.49507 10
-      vertex 0.345347 5.48915 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.345347 5.48915 10
-      vertex -0.468452 2.45572 10
-      vertex -0.156976 2.49507 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.0306 5.40258 10
-      vertex -0.468452 2.45572 10
-      vertex -0.345347 5.48915 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.468452 2.45572 10
-      vertex -1.0306 5.40258 10
-      vertex -0.772542 2.37764 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.69959 5.23081 10
-      vertex -0.772542 2.37764 10
-      vertex -1.0306 5.40258 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.772542 2.37764 10
-      vertex -1.69959 5.23081 10
-      vertex -1.06445 2.26207 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -2.34179 4.97655 10
-      vertex -1.06445 2.26207 10
-      vertex -1.69959 5.23081 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.06445 2.26207 10
-      vertex -2.34179 4.97655 10
-      vertex -1.33957 2.11082 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -2.94705 4.6438 10
-      vertex -1.33957 2.11082 10
-      vertex -2.34179 4.97655 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.33957 2.11082 10
-      vertex -2.94705 4.6438 10
-      vertex -1.59356 1.92628 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -3.50583 4.23782 10
-      vertex -1.59356 1.92628 10
-      vertex -2.94705 4.6438 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.59356 1.92628 10
-      vertex -3.50583 4.23782 10
-      vertex -1.82242 1.71137 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -4.00933 3.76501 10
-      vertex -1.82242 1.71137 10
-      vertex -3.50583 4.23782 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.82242 1.71137 10
-      vertex -4.00933 3.76501 10
-      vertex -2.02254 1.46946 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -4.44959 3.23282 10
-      vertex -2.02254 1.46946 10
-      vertex -4.00933 3.76501 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.02254 1.46946 10
-      vertex -4.44959 3.23282 10
-      vertex -2.19077 1.20438 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -4.81969 2.64964 10
-      vertex -2.19077 1.20438 10
-      vertex -4.44959 3.23282 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.81969 -2.64964 10
-      vertex 2.19077 -1.20438 10
-      vertex 4.44959 -3.23282 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.02254 -1.46946 10
-      vertex 4.44959 -3.23282 10
-      vertex 2.19077 -1.20438 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.44959 -3.23282 10
-      vertex 2.02254 -1.46946 10
-      vertex 4.00933 -3.76501 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 1.82242 -1.71137 10
-      vertex 4.00933 -3.76501 10
-      vertex 2.02254 -1.46946 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.00933 -3.76501 10
-      vertex 1.82242 -1.71137 10
-      vertex 3.50583 -4.23782 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 1.59356 -1.92628 10
-      vertex 3.50583 -4.23782 10
-      vertex 1.82242 -1.71137 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.50583 -4.23782 10
-      vertex 1.59356 -1.92628 10
-      vertex 2.94705 -4.6438 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 1.33957 -2.11082 10
-      vertex 2.94705 -4.6438 10
-      vertex 1.59356 -1.92628 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.94705 -4.6438 10
-      vertex 1.33957 -2.11082 10
-      vertex 2.34179 -4.97655 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 1.06445 -2.26207 10
-      vertex 2.34179 -4.97655 10
-      vertex 1.33957 -2.11082 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.34179 -4.97655 10
-      vertex 1.06445 -2.26207 10
-      vertex 1.69959 -5.23081 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.772542 -2.37764 10
-      vertex 1.69959 -5.23081 10
-      vertex 1.06445 -2.26207 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.69959 -5.23081 10
-      vertex 0.772542 -2.37764 10
-      vertex 1.0306 -5.40258 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.468452 -2.45572 10
-      vertex 1.0306 -5.40258 10
-      vertex 0.772542 -2.37764 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.468452 -2.45572 10
-      vertex 0.345347 -5.48915 10
-      vertex 1.0306 -5.40258 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.156976 -2.49507 10
-      vertex 0.345347 -5.48915 10
-      vertex 0.468452 -2.45572 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.156976 -2.49507 10
-      vertex 0.345347 -5.48915 10
-      vertex 0.156976 -2.49507 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.156976 -2.49507 10
-      vertex -0.345347 -5.48915 10
-      vertex 0.345347 -5.48915 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.468452 -2.45572 10
-      vertex -0.345347 -5.48915 10
-      vertex -0.156976 -2.49507 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.0306 -5.40258 10
-      vertex -0.468452 -2.45572 10
-      vertex -0.772542 -2.37764 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.468452 -2.45572 10
-      vertex -1.0306 -5.40258 10
-      vertex -0.345347 -5.48915 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.69959 -5.23081 10
-      vertex -0.772542 -2.37764 10
-      vertex -1.06445 -2.26207 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.34179 -4.97655 10
-      vertex -1.06445 -2.26207 10
-      vertex -1.33957 -2.11082 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.94705 -4.6438 10
-      vertex -1.33957 -2.11082 10
-      vertex -1.59356 -1.92628 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.772542 -2.37764 10
-      vertex -1.69959 -5.23081 10
-      vertex -1.0306 -5.40258 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -3.50583 -4.23782 10
-      vertex -1.59356 -1.92628 10
-      vertex -1.82242 -1.71137 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.00933 -3.76501 10
-      vertex -1.82242 -1.71137 10
-      vertex -2.02254 -1.46946 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.44959 -3.23282 10
-      vertex -2.02254 -1.46946 10
-      vertex -2.19077 -1.20438 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.81969 -2.64964 10
-      vertex -2.19077 -1.20438 10
-      vertex -2.32444 -0.920311 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.06445 -2.26207 10
-      vertex -2.34179 -4.97655 10
-      vertex -1.69959 -5.23081 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.11377 -2.02468 10
-      vertex -2.32444 -0.920311 10
-      vertex -2.42146 -0.621724 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.32721 -1.36779 10
-      vertex -2.42146 -0.621724 10
-      vertex -2.48029 -0.313333 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.45663 -0.689332 10
-      vertex -2.48029 -0.313333 10
-      vertex -2.5 0 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.19077 1.20438 10
-      vertex -4.81969 2.64964 10
-      vertex -2.32444 0.920311 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.33957 -2.11082 10
-      vertex -2.94705 -4.6438 10
-      vertex -2.34179 -4.97655 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.11377 2.02468 10
-      vertex -2.32444 0.920311 10
-      vertex -4.81969 2.64964 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.59356 -1.92628 10
-      vertex -3.50583 -4.23782 10
-      vertex -2.94705 -4.6438 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.32444 0.920311 10
-      vertex -5.11377 2.02468 10
-      vertex -2.42146 0.621724 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.82242 -1.71137 10
-      vertex -4.00933 -3.76501 10
-      vertex -3.50583 -4.23782 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.32721 1.36779 10
-      vertex -2.42146 0.621724 10
-      vertex -5.11377 2.02468 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.02254 -1.46946 10
-      vertex -4.44959 -3.23282 10
-      vertex -4.00933 -3.76501 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.42146 0.621724 10
-      vertex -5.32721 1.36779 10
-      vertex -2.48029 0.313333 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.19077 -1.20438 10
-      vertex -4.81969 -2.64964 10
-      vertex -4.44959 -3.23282 10
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.45663 0.689332 10
-      vertex -2.48029 0.313333 10
-      vertex -5.32721 1.36779 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.32444 -0.920311 10
-      vertex -5.11377 -2.02468 10
-      vertex -4.81969 -2.64964 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.48029 0.313333 10
-      vertex -5.45663 0.689332 10
-      vertex -2.5 0 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.42146 -0.621724 10
-      vertex -5.32721 -1.36779 10
-      vertex -5.11377 -2.02468 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.5 0 10
-      vertex -2.5 0 10
-      vertex -5.45663 0.689332 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.48029 -0.313333 10
-      vertex -5.45663 -0.689332 10
-      vertex -5.32721 -1.36779 10
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.5 0 10
-      vertex -5.5 0 10
-      vertex -5.45663 -0.689332 10
-    endloop
-  endfacet
-  facet normal -0.248699 0.968581 0
-    outer loop
-      vertex 0.772542 -2.37764 0
-      vertex 0.468452 -2.45572 10
-      vertex 0.772542 -2.37764 10
-    endloop
-  endfacet
-  facet normal -0.248699 0.968581 0
-    outer loop
-      vertex 0.468452 -2.45572 10
-      vertex 0.772542 -2.37764 0
-      vertex 0.468452 -2.45572 0
-    endloop
-  endfacet
-  facet normal -0.982287 -0.187385 0
-    outer loop
-      vertex 2.48029 0.313333 0
-      vertex 2.42146 0.621724 10
-      vertex 2.42146 0.621724 0
-    endloop
-  endfacet
-  facet normal -0.982287 -0.187385 0
-    outer loop
-      vertex 2.42146 0.621724 10
-      vertex 2.48029 0.313333 0
-      vertex 2.48029 0.313333 10
-    endloop
-  endfacet
-  facet normal -0.998027 -0.0627802 0
-    outer loop
-      vertex 2.5 0 0
-      vertex 2.48029 0.313333 10
-      vertex 2.48029 0.313333 0
-    endloop
-  endfacet
-  facet normal -0.998027 -0.0627802 0
-    outer loop
-      vertex 2.48029 0.313333 10
-      vertex 2.5 0 0
-      vertex 2.5 0 10
-    endloop
-  endfacet
-  facet normal -0.951054 -0.309026 0
-    outer loop
-      vertex 2.42146 0.621724 0
-      vertex 2.32444 0.920311 10
-      vertex 2.32444 0.920311 0
-    endloop
-  endfacet
-  facet normal -0.951054 -0.309026 0
-    outer loop
-      vertex 2.32444 0.920311 10
-      vertex 2.42146 0.621724 0
-      vertex 2.42146 0.621724 10
-    endloop
-  endfacet
-  facet normal -0.368112 -0.929781 0
-    outer loop
-      vertex 0.772542 2.37764 0
-      vertex 1.06445 2.26207 10
-      vertex 0.772542 2.37764 10
-    endloop
-  endfacet
-  facet normal -0.368112 -0.929781 -0
-    outer loop
-      vertex 1.06445 2.26207 10
-      vertex 0.772542 2.37764 0
-      vertex 1.06445 2.26207 0
-    endloop
-  endfacet
-  facet normal 0.951054 -0.309026 0
-    outer loop
-      vertex -2.42146 0.621724 10
-      vertex -2.32444 0.920311 0
-      vertex -2.32444 0.920311 10
-    endloop
-  endfacet
-  facet normal 0.951054 -0.309026 0
-    outer loop
-      vertex -2.32444 0.920311 0
-      vertex -2.42146 0.621724 10
-      vertex -2.42146 0.621724 0
-    endloop
-  endfacet
-  facet normal 0.770522 0.637414 0
-    outer loop
-      vertex -1.82242 -1.71137 10
-      vertex -2.02254 -1.46946 0
-      vertex -2.02254 -1.46946 10
-    endloop
-  endfacet
-  facet normal 0.770522 0.637414 0
-    outer loop
-      vertex -2.02254 -1.46946 0
-      vertex -1.82242 -1.71137 10
-      vertex -1.82242 -1.71137 0
-    endloop
-  endfacet
-  facet normal -0.998027 0.0627802 0
-    outer loop
-      vertex 2.48029 -0.313333 0
-      vertex 2.5 0 10
-      vertex 2.5 0 0
-    endloop
-  endfacet
-  facet normal -0.998027 0.0627802 0
-    outer loop
-      vertex 2.5 0 10
-      vertex 2.48029 -0.313333 0
-      vertex 2.48029 -0.313333 10
-    endloop
-  endfacet
-  facet normal -0.90483 -0.425772 0
-    outer loop
-      vertex 2.32444 0.920311 0
-      vertex 2.19077 1.20438 10
-      vertex 2.19077 1.20438 0
-    endloop
-  endfacet
-  facet normal -0.90483 -0.425772 0
-    outer loop
-      vertex 2.19077 1.20438 10
-      vertex 2.32444 0.920311 0
-      vertex 2.32444 0.920311 10
-    endloop
-  endfacet
-  facet normal 0.125338 -0.992114 0
-    outer loop
-      vertex -0.468452 2.45572 0
-      vertex -0.156976 2.49507 10
-      vertex -0.468452 2.45572 10
-    endloop
-  endfacet
-  facet normal 0.125338 -0.992114 0
-    outer loop
-      vertex -0.156976 2.49507 10
-      vertex -0.468452 2.45572 0
-      vertex -0.156976 2.49507 0
-    endloop
-  endfacet
-  facet normal -0.125338 -0.992114 0
-    outer loop
-      vertex 0.156976 2.49507 0
-      vertex 0.468452 2.45572 10
-      vertex 0.156976 2.49507 10
-    endloop
-  endfacet
-  facet normal -0.125338 -0.992114 -0
-    outer loop
-      vertex 0.468452 2.45572 10
-      vertex 0.156976 2.49507 0
-      vertex 0.468452 2.45572 0
-    endloop
-  endfacet
-  facet normal -0.587797 0.809009 0
-    outer loop
-      vertex 1.59356 -1.92628 0
-      vertex 1.33957 -2.11082 10
-      vertex 1.59356 -1.92628 10
-    endloop
-  endfacet
-  facet normal -0.587797 0.809009 0
-    outer loop
-      vertex 1.33957 -2.11082 10
-      vertex 1.59356 -1.92628 0
-      vertex 1.33957 -2.11082 0
-    endloop
-  endfacet
-  facet normal 0.587797 0.809009 -0
-    outer loop
-      vertex -1.33957 -2.11082 0
-      vertex -1.59356 -1.92628 10
-      vertex -1.33957 -2.11082 10
-    endloop
-  endfacet
-  facet normal 0.587797 0.809009 0
-    outer loop
-      vertex -1.59356 -1.92628 10
-      vertex -1.33957 -2.11082 0
-      vertex -1.59356 -1.92628 0
-    endloop
-  endfacet
-  facet normal 0.684541 -0.728975 0
-    outer loop
-      vertex -1.82242 1.71137 0
-      vertex -1.59356 1.92628 10
-      vertex -1.82242 1.71137 10
-    endloop
-  endfacet
-  facet normal 0.684541 -0.728975 0
-    outer loop
-      vertex -1.59356 1.92628 10
-      vertex -1.82242 1.71137 0
-      vertex -1.59356 1.92628 0
-    endloop
-  endfacet
-  facet normal -0.982287 0.187385 0
-    outer loop
-      vertex 2.42146 -0.621724 0
-      vertex 2.48029 -0.313333 10
-      vertex 2.48029 -0.313333 0
-    endloop
-  endfacet
-  facet normal -0.982287 0.187385 0
-    outer loop
-      vertex 2.48029 -0.313333 10
-      vertex 2.42146 -0.621724 0
-      vertex 2.42146 -0.621724 10
-    endloop
-  endfacet
-  facet normal -0.368112 0.929781 0
-    outer loop
-      vertex 1.06445 -2.26207 0
-      vertex 0.772542 -2.37764 10
-      vertex 1.06445 -2.26207 10
-    endloop
-  endfacet
-  facet normal -0.368112 0.929781 0
-    outer loop
-      vertex 0.772542 -2.37764 10
-      vertex 1.06445 -2.26207 0
-      vertex 0.772542 -2.37764 0
-    endloop
-  endfacet
-  facet normal -0.684541 0.728975 0
-    outer loop
-      vertex 1.82242 -1.71137 0
-      vertex 1.59356 -1.92628 10
-      vertex 1.82242 -1.71137 10
-    endloop
-  endfacet
-  facet normal -0.684541 0.728975 0
-    outer loop
-      vertex 1.59356 -1.92628 10
-      vertex 1.82242 -1.71137 0
-      vertex 1.59356 -1.92628 0
-    endloop
-  endfacet
-  facet normal -0.587797 -0.809009 0
-    outer loop
-      vertex 1.33957 2.11082 0
-      vertex 1.59356 1.92628 10
-      vertex 1.33957 2.11082 10
-    endloop
-  endfacet
-  facet normal -0.587797 -0.809009 -0
-    outer loop
-      vertex 1.59356 1.92628 10
-      vertex 1.33957 2.11082 0
-      vertex 1.59356 1.92628 0
-    endloop
-  endfacet
-  facet normal 0.368112 -0.929781 0
-    outer loop
-      vertex -1.06445 2.26207 0
-      vertex -0.772542 2.37764 10
-      vertex -1.06445 2.26207 10
-    endloop
-  endfacet
-  facet normal 0.368112 -0.929781 0
-    outer loop
-      vertex -0.772542 2.37764 10
-      vertex -1.06445 2.26207 0
-      vertex -0.772542 2.37764 0
-    endloop
-  endfacet
-  facet normal -0.844321 -0.535838 0
-    outer loop
-      vertex 2.19077 1.20438 0
-      vertex 2.02254 1.46946 10
-      vertex 2.02254 1.46946 0
-    endloop
-  endfacet
-  facet normal -0.844321 -0.535838 0
-    outer loop
-      vertex 2.02254 1.46946 10
-      vertex 2.19077 1.20438 0
-      vertex 2.19077 1.20438 10
-    endloop
-  endfacet
-  facet normal 0.248699 -0.968581 0
-    outer loop
-      vertex -0.772542 2.37764 0
-      vertex -0.468452 2.45572 10
-      vertex -0.772542 2.37764 10
-    endloop
-  endfacet
-  facet normal 0.248699 -0.968581 0
-    outer loop
-      vertex -0.468452 2.45572 10
-      vertex -0.772542 2.37764 0
-      vertex -0.468452 2.45572 0
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 0
-    outer loop
-      vertex 1.06445 2.26207 0
-      vertex 1.33957 2.11082 10
-      vertex 1.06445 2.26207 10
-    endloop
-  endfacet
-  facet normal -0.481757 -0.876305 -0
-    outer loop
-      vertex 1.33957 2.11082 10
-      vertex 1.06445 2.26207 0
-      vertex 1.33957 2.11082 0
-    endloop
-  endfacet
-  facet normal 0.248699 0.968581 -0
-    outer loop
-      vertex -0.468452 -2.45572 0
-      vertex -0.772542 -2.37764 10
-      vertex -0.468452 -2.45572 10
-    endloop
-  endfacet
-  facet normal 0.248699 0.968581 0
-    outer loop
-      vertex -0.772542 -2.37764 10
-      vertex -0.468452 -2.45572 0
-      vertex -0.772542 -2.37764 0
-    endloop
-  endfacet
-  facet normal 0.587797 -0.809009 0
-    outer loop
-      vertex -1.59356 1.92628 0
-      vertex -1.33957 2.11082 10
-      vertex -1.59356 1.92628 10
-    endloop
-  endfacet
-  facet normal 0.587797 -0.809009 0
-    outer loop
-      vertex -1.33957 2.11082 10
-      vertex -1.59356 1.92628 0
-      vertex -1.33957 2.11082 0
-    endloop
-  endfacet
-  facet normal -0.125338 0.992114 0
-    outer loop
-      vertex 0.468452 -2.45572 0
-      vertex 0.156976 -2.49507 10
-      vertex 0.468452 -2.45572 10
-    endloop
-  endfacet
-  facet normal -0.125338 0.992114 0
-    outer loop
-      vertex 0.156976 -2.49507 10
-      vertex 0.468452 -2.45572 0
-      vertex 0.156976 -2.49507 0
-    endloop
-  endfacet
-  facet normal -0.684541 -0.728975 0
-    outer loop
-      vertex 1.59356 1.92628 0
-      vertex 1.82242 1.71137 10
-      vertex 1.59356 1.92628 10
-    endloop
-  endfacet
-  facet normal -0.684541 -0.728975 -0
-    outer loop
-      vertex 1.82242 1.71137 10
-      vertex 1.59356 1.92628 0
-      vertex 1.82242 1.71137 0
-    endloop
-  endfacet
-  facet normal -0.770522 0.637414 0
-    outer loop
-      vertex 1.82242 -1.71137 0
-      vertex 2.02254 -1.46946 10
-      vertex 2.02254 -1.46946 0
-    endloop
-  endfacet
-  facet normal -0.770522 0.637414 0
-    outer loop
-      vertex 2.02254 -1.46946 10
-      vertex 1.82242 -1.71137 0
-      vertex 1.82242 -1.71137 10
-    endloop
-  endfacet
-  facet normal 0.951054 0.309026 0
-    outer loop
-      vertex -2.32444 -0.920311 10
-      vertex -2.42146 -0.621724 0
-      vertex -2.42146 -0.621724 10
-    endloop
-  endfacet
-  facet normal 0.951054 0.309026 0
-    outer loop
-      vertex -2.42146 -0.621724 0
-      vertex -2.32444 -0.920311 10
-      vertex -2.32444 -0.920311 0
-    endloop
-  endfacet
-  facet normal -0.770522 -0.637414 0
-    outer loop
-      vertex 2.02254 1.46946 0
-      vertex 1.82242 1.71137 10
-      vertex 1.82242 1.71137 0
-    endloop
-  endfacet
-  facet normal -0.770522 -0.637414 0
-    outer loop
-      vertex 1.82242 1.71137 10
-      vertex 2.02254 1.46946 0
-      vertex 2.02254 1.46946 10
-    endloop
-  endfacet
-  facet normal -0.951054 0.309026 0
-    outer loop
-      vertex 2.32444 -0.920311 0
-      vertex 2.42146 -0.621724 10
-      vertex 2.42146 -0.621724 0
-    endloop
-  endfacet
-  facet normal -0.951054 0.309026 0
-    outer loop
-      vertex 2.42146 -0.621724 10
-      vertex 2.32444 -0.920311 0
-      vertex 2.32444 -0.920311 10
-    endloop
-  endfacet
-  facet normal -0.844321 0.535838 0
-    outer loop
-      vertex 2.02254 -1.46946 0
-      vertex 2.19077 -1.20438 10
-      vertex 2.19077 -1.20438 0
-    endloop
-  endfacet
-  facet normal -0.844321 0.535838 0
-    outer loop
-      vertex 2.19077 -1.20438 10
-      vertex 2.02254 -1.46946 0
-      vertex 2.02254 -1.46946 10
-    endloop
-  endfacet
-  facet normal 0.481757 0.876305 -0
-    outer loop
-      vertex -1.06445 -2.26207 0
-      vertex -1.33957 -2.11082 10
-      vertex -1.06445 -2.26207 10
-    endloop
-  endfacet
-  facet normal 0.481757 0.876305 0
-    outer loop
-      vertex -1.33957 -2.11082 10
-      vertex -1.06445 -2.26207 0
-      vertex -1.33957 -2.11082 0
-    endloop
-  endfacet
-  facet normal -0.90483 0.425772 0
-    outer loop
-      vertex 2.19077 -1.20438 0
-      vertex 2.32444 -0.920311 10
-      vertex 2.32444 -0.920311 0
-    endloop
-  endfacet
-  facet normal -0.90483 0.425772 0
-    outer loop
-      vertex 2.32444 -0.920311 10
-      vertex 2.19077 -1.20438 0
-      vertex 2.19077 -1.20438 10
-    endloop
-  endfacet
-  facet normal 0.684541 0.728975 -0
-    outer loop
-      vertex -1.59356 -1.92628 0
-      vertex -1.82242 -1.71137 10
-      vertex -1.59356 -1.92628 10
-    endloop
-  endfacet
-  facet normal 0.684541 0.728975 0
-    outer loop
-      vertex -1.82242 -1.71137 10
-      vertex -1.59356 -1.92628 0
-      vertex -1.82242 -1.71137 0
-    endloop
-  endfacet
-  facet normal 0.998027 0.0627802 0
-    outer loop
-      vertex -2.48029 -0.313333 10
-      vertex -2.5 0 0
-      vertex -2.5 0 10
-    endloop
-  endfacet
-  facet normal 0.998027 0.0627802 0
-    outer loop
-      vertex -2.5 0 0
-      vertex -2.48029 -0.313333 10
-      vertex -2.48029 -0.313333 0
-    endloop
-  endfacet
-  facet normal 0.125338 0.992114 -0
-    outer loop
-      vertex -0.156976 -2.49507 0
-      vertex -0.468452 -2.45572 10
-      vertex -0.156976 -2.49507 10
-    endloop
-  endfacet
-  facet normal 0.125338 0.992114 0
-    outer loop
-      vertex -0.468452 -2.45572 10
-      vertex -0.156976 -2.49507 0
-      vertex -0.468452 -2.45572 0
-    endloop
-  endfacet
-  facet normal 0.90483 0.425772 0
-    outer loop
-      vertex -2.19077 -1.20438 10
-      vertex -2.32444 -0.920311 0
-      vertex -2.32444 -0.920311 10
-    endloop
-  endfacet
-  facet normal 0.90483 0.425772 0
-    outer loop
-      vertex -2.32444 -0.920311 0
-      vertex -2.19077 -1.20438 10
-      vertex -2.19077 -1.20438 0
-    endloop
-  endfacet
-  facet normal 0.982287 0.187385 0
-    outer loop
-      vertex -2.42146 -0.621724 10
-      vertex -2.48029 -0.313333 0
-      vertex -2.48029 -0.313333 10
-    endloop
-  endfacet
-  facet normal 0.982287 0.187385 0
-    outer loop
-      vertex -2.48029 -0.313333 0
-      vertex -2.42146 -0.621724 10
-      vertex -2.42146 -0.621724 0
-    endloop
-  endfacet
-  facet normal -0.248699 -0.968581 0
-    outer loop
-      vertex 0.468452 2.45572 0
-      vertex 0.772542 2.37764 10
-      vertex 0.468452 2.45572 10
-    endloop
-  endfacet
-  facet normal -0.248699 -0.968581 -0
-    outer loop
-      vertex 0.772542 2.37764 10
-      vertex 0.468452 2.45572 0
-      vertex 0.772542 2.37764 0
-    endloop
-  endfacet
-  facet normal 0.844321 0.535838 0
-    outer loop
-      vertex -2.02254 -1.46946 10
-      vertex -2.19077 -1.20438 0
-      vertex -2.19077 -1.20438 10
-    endloop
-  endfacet
-  facet normal 0.844321 0.535838 0
-    outer loop
-      vertex -2.19077 -1.20438 0
-      vertex -2.02254 -1.46946 10
-      vertex -2.02254 -1.46946 0
-    endloop
-  endfacet
-  facet normal 0.998027 -0.0627802 0
-    outer loop
-      vertex -2.5 0 10
-      vertex -2.48029 0.313333 0
-      vertex -2.48029 0.313333 10
-    endloop
-  endfacet
-  facet normal 0.998027 -0.0627802 0
-    outer loop
-      vertex -2.48029 0.313333 0
-      vertex -2.5 0 10
-      vertex -2.5 0 0
-    endloop
-  endfacet
-  facet normal 0.481757 -0.876305 0
-    outer loop
-      vertex -1.33957 2.11082 0
-      vertex -1.06445 2.26207 10
-      vertex -1.33957 2.11082 10
-    endloop
-  endfacet
-  facet normal 0.481757 -0.876305 0
-    outer loop
-      vertex -1.06445 2.26207 10
-      vertex -1.33957 2.11082 0
-      vertex -1.06445 2.26207 0
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.156976 -2.49507 0
-      vertex -0.156976 -2.49507 10
-      vertex 0.156976 -2.49507 10
+      vertex 0.3453474 5.489146 0
+      vertex -0.3453474 5.489146 10
+      vertex 0.3453474 5.489146 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.156976 -2.49507 10
-      vertex 0.156976 -2.49507 0
-      vertex -0.156976 -2.49507 0
+      vertex -0.3453474 5.489146 10
+      vertex 0.3453474 5.489146 0
+      vertex -0.3453474 5.489146 0
     endloop
   endfacet
-  facet normal 0.844321 -0.535838 0
+  facet normal -0.8443279 -0.5358268 0
     outer loop
-      vertex -2.19077 1.20438 10
-      vertex -2.02254 1.46946 0
-      vertex -2.02254 1.46946 10
+      vertex -4.4495926 -3.2328186 0
+      vertex -4.819686 -2.6496449 10
+      vertex -4.819686 -2.6496449 0
     endloop
   endfacet
-  facet normal 0.844321 -0.535838 0
+  facet normal -0.8443279 -0.5358268 0
     outer loop
-      vertex -2.02254 1.46946 0
-      vertex -2.19077 1.20438 10
-      vertex -2.19077 1.20438 0
+      vertex -4.819686 -2.6496449 10
+      vertex -4.4495926 -3.2328186 0
+      vertex -4.4495926 -3.2328186 10
     endloop
   endfacet
-  facet normal 0.368112 0.929781 -0
+  facet normal -0.7705136 -0.6374236 0
     outer loop
-      vertex -0.772542 -2.37764 0
-      vertex -1.06445 -2.26207 10
-      vertex -0.772542 -2.37764 10
+      vertex -4.009327 -3.765009 0
+      vertex -4.4495926 -3.2328186 10
+      vertex -4.4495926 -3.2328186 0
     endloop
   endfacet
-  facet normal 0.368112 0.929781 0
+  facet normal -0.7705136 -0.6374236 0
     outer loop
-      vertex -1.06445 -2.26207 10
-      vertex -0.772542 -2.37764 0
-      vertex -1.06445 -2.26207 0
+      vertex -4.4495926 -3.2328186 10
+      vertex -4.009327 -3.765009 0
+      vertex -4.009327 -3.765009 10
     endloop
   endfacet
-  facet normal 0.982287 -0.187385 0
+  facet normal -0.7705136 0.6374236 0
     outer loop
-      vertex -2.48029 0.313333 10
-      vertex -2.42146 0.621724 0
-      vertex -2.42146 0.621724 10
+      vertex -4.4495926 3.2328186 0
+      vertex -4.009327 3.765009 10
+      vertex -4.009327 3.765009 0
     endloop
   endfacet
-  facet normal 0.982287 -0.187385 0
+  facet normal -0.7705136 0.6374236 0
     outer loop
-      vertex -2.42146 0.621724 0
-      vertex -2.48029 0.313333 10
-      vertex -2.48029 0.313333 0
+      vertex -4.009327 3.765009 10
+      vertex -4.4495926 3.2328186 0
+      vertex -4.4495926 3.2328186 10
+    endloop
+  endfacet
+  facet normal 0.8443279 0.5358268 0
+    outer loop
+      vertex 4.819686 2.6496449 10
+      vertex 4.4495926 3.2328186 0
+      vertex 4.4495926 3.2328186 10
+    endloop
+  endfacet
+  facet normal 0.8443279 0.5358268 0
+    outer loop
+      vertex 4.4495926 3.2328186 0
+      vertex 4.819686 2.6496449 10
+      vertex 4.819686 2.6496449 0
+    endloop
+  endfacet
+  facet normal 0.24869016 0.9685831 0
+    outer loop
+      vertex 1.6995926 5.23081 0
+      vertex 1.0305967 5.4025793 10
+      vertex 1.6995926 5.23081 10
+    endloop
+  endfacet
+  facet normal 0.24869016 0.9685831 0
+    outer loop
+      vertex 1.0305967 5.4025793 10
+      vertex 1.6995926 5.23081 0
+      vertex 1.0305967 5.4025793 0
+    endloop
+  endfacet
+  facet normal 0.6845472 0.72896856 0
+    outer loop
+      vertex 4.009327 3.765009 0
+      vertex 3.5058317 4.2378225 10
+      vertex 4.009327 3.765009 10
+    endloop
+  endfacet
+  facet normal 0.6845472 0.72896856 0
+    outer loop
+      vertex 3.5058317 4.2378225 10
+      vertex 4.009327 3.765009 0
+      vertex 3.5058317 4.2378225 0
+    endloop
+  endfacet
+  facet normal 0.8443279 -0.5358268 0
+    outer loop
+      vertex 4.4495926 -3.2328186 10
+      vertex 4.819686 -2.6496449 0
+      vertex 4.819686 -2.6496449 10
+    endloop
+  endfacet
+  facet normal 0.8443279 -0.5358268 0
+    outer loop
+      vertex 4.819686 -2.6496449 0
+      vertex 4.4495926 -3.2328186 10
+      vertex 4.4495926 -3.2328186 0
+    endloop
+  endfacet
+  facet normal -0.9510568 0.30901614 0
+    outer loop
+      vertex -5.3272066 1.367794 0
+      vertex -5.1137705 2.024685 10
+      vertex -5.1137705 2.024685 0
+    endloop
+  endfacet
+  facet normal -0.9510568 0.30901614 0
+    outer loop
+      vertex -5.1137705 2.024685 10
+      vertex -5.3272066 1.367794 0
+      vertex -5.3272066 1.367794 10
+    endloop
+  endfacet
+  facet normal -0.36812434 0.92977655 0
+    outer loop
+      vertex -1.6995926 5.23081 0
+      vertex -2.3417854 4.976548 10
+      vertex -1.6995926 5.23081 10
+    endloop
+  endfacet
+  facet normal -0.36812434 0.92977655 0
+    outer loop
+      vertex -2.3417854 4.976548 10
+      vertex -1.6995926 5.23081 0
+      vertex -2.3417854 4.976548 0
+    endloop
+  endfacet
+  facet normal 0.9980267 -0.0627908 0
+    outer loop
+      vertex 5.4566307 -0.689332 10
+      vertex 5.5 0 0
+      vertex 5.5 0 10
+    endloop
+  endfacet
+  facet normal 0.9980267 -0.0627908 0
+    outer loop
+      vertex 5.5 0 0
+      vertex 5.4566307 -0.689332 10
+      vertex 5.4566307 -0.689332 0
+    endloop
+  endfacet
+  facet normal 0.5877847 0.8090174 0
+    outer loop
+      vertex 3.5058317 4.2378225 0
+      vertex 2.9470472 4.6438026 10
+      vertex 3.5058317 4.2378225 10
+    endloop
+  endfacet
+  facet normal 0.5877847 0.8090174 0
+    outer loop
+      vertex 2.9470472 4.6438026 10
+      vertex 3.5058317 4.2378225 0
+      vertex 2.9470472 4.6438026 0
+    endloop
+  endfacet
+  facet normal -0.5877847 0.8090174 0
+    outer loop
+      vertex -2.9470472 4.6438026 0
+      vertex -3.5058317 4.2378225 10
+      vertex -2.9470472 4.6438026 10
+    endloop
+  endfacet
+  facet normal -0.5877847 0.8090174 0
+    outer loop
+      vertex -3.5058317 4.2378225 10
+      vertex -2.9470472 4.6438026 0
+      vertex -3.5058317 4.2378225 0
+    endloop
+  endfacet
+  facet normal 0.9510568 -0.30901614 0
+    outer loop
+      vertex 5.1137705 -2.024685 10
+      vertex 5.3272066 -1.367794 0
+      vertex 5.3272066 -1.367794 10
+    endloop
+  endfacet
+  facet normal 0.9510568 -0.30901614 0
+    outer loop
+      vertex 5.3272066 -1.367794 0
+      vertex 5.1137705 -2.024685 10
+      vertex 5.1137705 -2.024685 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.5 0 10
+      vertex 5.5 0 10
+      vertex 5.4566307 0.689332 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.4802866 0.31333256 10
+      vertex 5.4566307 0.689332 10
+      vertex 5.3272066 1.367794 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.5 0 10
+      vertex 2.5 0 10
+      vertex 5.4566307 -0.689332 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.4214573 0.6217241 10
+      vertex 5.3272066 1.367794 10
+      vertex 5.1137705 2.024685 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.4802866 -0.31333256 10
+      vertex 5.4566307 -0.689332 10
+      vertex 2.5 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.324441 0.920311 10
+      vertex 5.1137705 2.024685 10
+      vertex 4.819686 2.6496449 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.4566307 -0.689332 10
+      vertex 2.4802866 -0.31333256 10
+      vertex 5.3272066 -1.367794 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.1907663 1.2043839 10
+      vertex 4.819686 2.6496449 10
+      vertex 4.4495926 3.2328186 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.4214573 -0.6217241 10
+      vertex 5.3272066 -1.367794 10
+      vertex 2.4802866 -0.31333256 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.022542 1.4694624 10
+      vertex 4.4495926 3.2328186 10
+      vertex 4.009327 3.765009 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.3272066 -1.367794 10
+      vertex 2.4214573 -0.6217241 10
+      vertex 5.1137705 -2.024685 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.8224211 1.7113676 10
+      vertex 4.009327 3.765009 10
+      vertex 3.5058317 4.2378225 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.324441 -0.920311 10
+      vertex 5.1137705 -2.024685 10
+      vertex 2.4214573 -0.6217241 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.5935593 1.9262829 10
+      vertex 3.5058317 4.2378225 10
+      vertex 2.9470472 4.6438026 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.1137705 -2.024685 10
+      vertex 2.324441 -0.920311 10
+      vertex 4.819686 -2.6496449 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.1907663 -1.2043839 10
+      vertex 4.819686 -2.6496449 10
+      vertex 2.324441 -0.920311 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.4566307 0.689332 10
+      vertex 2.4802866 0.31333256 10
+      vertex 2.5 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.3272066 1.367794 10
+      vertex 2.4214573 0.6217241 10
+      vertex 2.4802866 0.31333256 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.3395662 2.1108189 10
+      vertex 2.9470472 4.6438026 10
+      vertex 2.3417854 4.976548 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.1137705 2.024685 10
+      vertex 2.324441 0.920311 10
+      vertex 2.4214573 0.6217241 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.819686 2.6496449 10
+      vertex 2.1907663 1.2043839 10
+      vertex 2.324441 0.920311 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.4495926 3.2328186 10
+      vertex 2.022542 1.4694624 10
+      vertex 2.1907663 1.2043839 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.009327 3.765009 10
+      vertex 1.8224211 1.7113676 10
+      vertex 2.022542 1.4694624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.0644474 2.2620668 10
+      vertex 2.3417854 4.976548 10
+      vertex 1.6995926 5.23081 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5058317 4.2378225 10
+      vertex 1.5935593 1.9262829 10
+      vertex 1.8224211 1.7113676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.9470472 4.6438026 10
+      vertex 1.3395662 2.1108189 10
+      vertex 1.5935593 1.9262829 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.3417854 4.976548 10
+      vertex 1.0644474 2.2620668 10
+      vertex 1.3395662 2.1108189 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.772542 2.3776407 10
+      vertex 1.6995926 5.23081 10
+      vertex 1.0305967 5.4025793 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.6995926 5.23081 10
+      vertex 0.772542 2.3776407 10
+      vertex 1.0644474 2.2620668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.0305967 5.4025793 10
+      vertex 0.46845245 2.455718 10
+      vertex 0.772542 2.3776407 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.3453474 5.489146 10
+      vertex 0.46845245 2.455718 10
+      vertex 1.0305967 5.4025793 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.3453474 5.489146 10
+      vertex 0.15697575 2.4950666 10
+      vertex 0.46845245 2.455718 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.3453474 5.489146 10
+      vertex -0.15697575 2.4950666 10
+      vertex 0.15697575 2.4950666 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.3453474 5.489146 10
+      vertex -0.15697575 2.4950666 10
+      vertex 0.3453474 5.489146 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.3453474 5.489146 10
+      vertex -0.46845245 2.455718 10
+      vertex -0.15697575 2.4950666 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.0305967 5.4025793 10
+      vertex -0.46845245 2.455718 10
+      vertex -0.3453474 5.489146 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.46845245 2.455718 10
+      vertex -1.0305967 5.4025793 10
+      vertex -0.772542 2.3776407 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.6995926 5.23081 10
+      vertex -0.772542 2.3776407 10
+      vertex -1.0305967 5.4025793 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.772542 2.3776407 10
+      vertex -1.6995926 5.23081 10
+      vertex -1.0644474 2.2620668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.3417854 4.976548 10
+      vertex -1.0644474 2.2620668 10
+      vertex -1.6995926 5.23081 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.0644474 2.2620668 10
+      vertex -2.3417854 4.976548 10
+      vertex -1.3395662 2.1108189 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.9470472 4.6438026 10
+      vertex -1.3395662 2.1108189 10
+      vertex -2.3417854 4.976548 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.3395662 2.1108189 10
+      vertex -2.9470472 4.6438026 10
+      vertex -1.5935593 1.9262829 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.5058317 4.2378225 10
+      vertex -1.5935593 1.9262829 10
+      vertex -2.9470472 4.6438026 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.5935593 1.9262829 10
+      vertex -3.5058317 4.2378225 10
+      vertex -1.8224211 1.7113676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.009327 3.765009 10
+      vertex -1.8224211 1.7113676 10
+      vertex -3.5058317 4.2378225 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.8224211 1.7113676 10
+      vertex -4.009327 3.765009 10
+      vertex -2.022542 1.4694624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.4495926 3.2328186 10
+      vertex -2.022542 1.4694624 10
+      vertex -4.009327 3.765009 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.022542 1.4694624 10
+      vertex -4.4495926 3.2328186 10
+      vertex -2.1907663 1.2043839 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.819686 2.6496449 10
+      vertex -2.1907663 1.2043839 10
+      vertex -4.4495926 3.2328186 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.819686 -2.6496449 10
+      vertex 2.1907663 -1.2043839 10
+      vertex 4.4495926 -3.2328186 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.022542 -1.4694624 10
+      vertex 4.4495926 -3.2328186 10
+      vertex 2.1907663 -1.2043839 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.4495926 -3.2328186 10
+      vertex 2.022542 -1.4694624 10
+      vertex 4.009327 -3.765009 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.8224211 -1.7113676 10
+      vertex 4.009327 -3.765009 10
+      vertex 2.022542 -1.4694624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.009327 -3.765009 10
+      vertex 1.8224211 -1.7113676 10
+      vertex 3.5058317 -4.2378225 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.5935593 -1.9262829 10
+      vertex 3.5058317 -4.2378225 10
+      vertex 1.8224211 -1.7113676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5058317 -4.2378225 10
+      vertex 1.5935593 -1.9262829 10
+      vertex 2.9470472 -4.6438026 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.3395662 -2.1108189 10
+      vertex 2.9470472 -4.6438026 10
+      vertex 1.5935593 -1.9262829 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.9470472 -4.6438026 10
+      vertex 1.3395662 -2.1108189 10
+      vertex 2.3417854 -4.976548 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.0644474 -2.2620668 10
+      vertex 2.3417854 -4.976548 10
+      vertex 1.3395662 -2.1108189 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.3417854 -4.976548 10
+      vertex 1.0644474 -2.2620668 10
+      vertex 1.6995926 -5.23081 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.772542 -2.3776407 10
+      vertex 1.6995926 -5.23081 10
+      vertex 1.0644474 -2.2620668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.6995926 -5.23081 10
+      vertex 0.772542 -2.3776407 10
+      vertex 1.0305967 -5.4025793 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.46845245 -2.455718 10
+      vertex 1.0305967 -5.4025793 10
+      vertex 0.772542 -2.3776407 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.46845245 -2.455718 10
+      vertex 0.3453474 -5.489146 10
+      vertex 1.0305967 -5.4025793 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.15697575 -2.4950666 10
+      vertex 0.3453474 -5.489146 10
+      vertex 0.46845245 -2.455718 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.15697575 -2.4950666 10
+      vertex 0.3453474 -5.489146 10
+      vertex 0.15697575 -2.4950666 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.15697575 -2.4950666 10
+      vertex -0.3453474 -5.489146 10
+      vertex 0.3453474 -5.489146 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.46845245 -2.455718 10
+      vertex -0.3453474 -5.489146 10
+      vertex -0.15697575 -2.4950666 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.0305967 -5.4025793 10
+      vertex -0.46845245 -2.455718 10
+      vertex -0.772542 -2.3776407 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.46845245 -2.455718 10
+      vertex -1.0305967 -5.4025793 10
+      vertex -0.3453474 -5.489146 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.6995926 -5.23081 10
+      vertex -0.772542 -2.3776407 10
+      vertex -1.0644474 -2.2620668 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.3417854 -4.976548 10
+      vertex -1.0644474 -2.2620668 10
+      vertex -1.3395662 -2.1108189 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.9470472 -4.6438026 10
+      vertex -1.3395662 -2.1108189 10
+      vertex -1.5935593 -1.9262829 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.772542 -2.3776407 10
+      vertex -1.6995926 -5.23081 10
+      vertex -1.0305967 -5.4025793 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.5058317 -4.2378225 10
+      vertex -1.5935593 -1.9262829 10
+      vertex -1.8224211 -1.7113676 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.009327 -3.765009 10
+      vertex -1.8224211 -1.7113676 10
+      vertex -2.022542 -1.4694624 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.4495926 -3.2328186 10
+      vertex -2.022542 -1.4694624 10
+      vertex -2.1907663 -1.2043839 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.819686 -2.6496449 10
+      vertex -2.1907663 -1.2043839 10
+      vertex -2.324441 -0.920311 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.0644474 -2.2620668 10
+      vertex -2.3417854 -4.976548 10
+      vertex -1.6995926 -5.23081 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.1137705 -2.024685 10
+      vertex -2.324441 -0.920311 10
+      vertex -2.4214573 -0.6217241 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.3272066 -1.367794 10
+      vertex -2.4214573 -0.6217241 10
+      vertex -2.4802866 -0.31333256 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.4566307 -0.689332 10
+      vertex -2.4802866 -0.31333256 10
+      vertex -2.5 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.1907663 1.2043839 10
+      vertex -4.819686 2.6496449 10
+      vertex -2.324441 0.920311 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.3395662 -2.1108189 10
+      vertex -2.9470472 -4.6438026 10
+      vertex -2.3417854 -4.976548 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.1137705 2.024685 10
+      vertex -2.324441 0.920311 10
+      vertex -4.819686 2.6496449 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.5935593 -1.9262829 10
+      vertex -3.5058317 -4.2378225 10
+      vertex -2.9470472 -4.6438026 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.324441 0.920311 10
+      vertex -5.1137705 2.024685 10
+      vertex -2.4214573 0.6217241 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.8224211 -1.7113676 10
+      vertex -4.009327 -3.765009 10
+      vertex -3.5058317 -4.2378225 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.3272066 1.367794 10
+      vertex -2.4214573 0.6217241 10
+      vertex -5.1137705 2.024685 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.022542 -1.4694624 10
+      vertex -4.4495926 -3.2328186 10
+      vertex -4.009327 -3.765009 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.4214573 0.6217241 10
+      vertex -5.3272066 1.367794 10
+      vertex -2.4802866 0.31333256 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.1907663 -1.2043839 10
+      vertex -4.819686 -2.6496449 10
+      vertex -4.4495926 -3.2328186 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.4566307 0.689332 10
+      vertex -2.4802866 0.31333256 10
+      vertex -5.3272066 1.367794 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.324441 -0.920311 10
+      vertex -5.1137705 -2.024685 10
+      vertex -4.819686 -2.6496449 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.4802866 0.31333256 10
+      vertex -5.4566307 0.689332 10
+      vertex -2.5 0 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.4214573 -0.6217241 10
+      vertex -5.3272066 -1.367794 10
+      vertex -5.1137705 -2.024685 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 0 10
+      vertex -2.5 0 10
+      vertex -5.4566307 0.689332 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.4802866 -0.31333256 10
+      vertex -5.4566307 -0.689332 10
+      vertex -5.3272066 -1.367794 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.5 0 10
+      vertex -5.5 0 10
+      vertex -5.4566307 -0.689332 10
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.5 0 0
+      vertex 5.5 0 0
+      vertex 5.4566307 -0.689332 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.4802866 -0.31333256 0
+      vertex 5.4566307 -0.689332 0
+      vertex 5.3272066 -1.367794 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.5 0 0
+      vertex 2.5 0 0
+      vertex 5.4566307 0.689332 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.4214573 -0.6217241 0
+      vertex 5.3272066 -1.367794 0
+      vertex 5.1137705 -2.024685 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.4802866 0.31333256 0
+      vertex 5.4566307 0.689332 0
+      vertex 2.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.324441 -0.920311 0
+      vertex 5.1137705 -2.024685 0
+      vertex 4.819686 -2.6496449 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.4566307 0.689332 0
+      vertex 2.4802866 0.31333256 0
+      vertex 5.3272066 1.367794 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.1907663 -1.2043839 0
+      vertex 4.819686 -2.6496449 0
+      vertex 4.4495926 -3.2328186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.4214573 0.6217241 0
+      vertex 5.3272066 1.367794 0
+      vertex 2.4802866 0.31333256 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.022542 -1.4694624 0
+      vertex 4.4495926 -3.2328186 0
+      vertex 4.009327 -3.765009 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.3272066 1.367794 0
+      vertex 2.4214573 0.6217241 0
+      vertex 5.1137705 2.024685 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.8224211 -1.7113676 0
+      vertex 4.009327 -3.765009 0
+      vertex 3.5058317 -4.2378225 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.324441 0.920311 0
+      vertex 5.1137705 2.024685 0
+      vertex 2.4214573 0.6217241 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.5935593 -1.9262829 0
+      vertex 3.5058317 -4.2378225 0
+      vertex 2.9470472 -4.6438026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.1137705 2.024685 0
+      vertex 2.324441 0.920311 0
+      vertex 4.819686 2.6496449 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.1907663 1.2043839 0
+      vertex 4.819686 2.6496449 0
+      vertex 2.324441 0.920311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.4566307 -0.689332 0
+      vertex 2.4802866 -0.31333256 0
+      vertex 2.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.3272066 -1.367794 0
+      vertex 2.4214573 -0.6217241 0
+      vertex 2.4802866 -0.31333256 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3395662 -2.1108189 0
+      vertex 2.9470472 -4.6438026 0
+      vertex 2.3417854 -4.976548 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.1137705 -2.024685 0
+      vertex 2.324441 -0.920311 0
+      vertex 2.4214573 -0.6217241 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.819686 -2.6496449 0
+      vertex 2.1907663 -1.2043839 0
+      vertex 2.324441 -0.920311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.4495926 -3.2328186 0
+      vertex 2.022542 -1.4694624 0
+      vertex 2.1907663 -1.2043839 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.009327 -3.765009 0
+      vertex 1.8224211 -1.7113676 0
+      vertex 2.022542 -1.4694624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0644474 -2.2620668 0
+      vertex 2.3417854 -4.976548 0
+      vertex 1.6995926 -5.23081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.5058317 -4.2378225 0
+      vertex 1.5935593 -1.9262829 0
+      vertex 1.8224211 -1.7113676 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.9470472 -4.6438026 0
+      vertex 1.3395662 -2.1108189 0
+      vertex 1.5935593 -1.9262829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.3417854 -4.976548 0
+      vertex 1.0644474 -2.2620668 0
+      vertex 1.3395662 -2.1108189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.772542 -2.3776407 0
+      vertex 1.6995926 -5.23081 0
+      vertex 1.0305967 -5.4025793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.6995926 -5.23081 0
+      vertex 0.772542 -2.3776407 0
+      vertex 1.0644474 -2.2620668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0305967 -5.4025793 0
+      vertex 0.46845245 -2.455718 0
+      vertex 0.772542 -2.3776407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.3453474 -5.489146 0
+      vertex 0.46845245 -2.455718 0
+      vertex 1.0305967 -5.4025793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.3453474 -5.489146 0
+      vertex 0.15697575 -2.4950666 0
+      vertex 0.46845245 -2.455718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.3453474 -5.489146 0
+      vertex -0.15697575 -2.4950666 0
+      vertex 0.15697575 -2.4950666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.3453474 -5.489146 0
+      vertex -0.15697575 -2.4950666 0
+      vertex 0.3453474 -5.489146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.3453474 -5.489146 0
+      vertex -0.46845245 -2.455718 0
+      vertex -0.15697575 -2.4950666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0305967 -5.4025793 0
+      vertex -0.46845245 -2.455718 0
+      vertex -0.3453474 -5.489146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46845245 -2.455718 0
+      vertex -1.0305967 -5.4025793 0
+      vertex -0.772542 -2.3776407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.6995926 -5.23081 0
+      vertex -0.772542 -2.3776407 0
+      vertex -1.0305967 -5.4025793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.772542 -2.3776407 0
+      vertex -1.6995926 -5.23081 0
+      vertex -1.0644474 -2.2620668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.3417854 -4.976548 0
+      vertex -1.0644474 -2.2620668 0
+      vertex -1.6995926 -5.23081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0644474 -2.2620668 0
+      vertex -2.3417854 -4.976548 0
+      vertex -1.3395662 -2.1108189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.9470472 -4.6438026 0
+      vertex -1.3395662 -2.1108189 0
+      vertex -2.3417854 -4.976548 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3395662 -2.1108189 0
+      vertex -2.9470472 -4.6438026 0
+      vertex -1.5935593 -1.9262829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5058317 -4.2378225 0
+      vertex -1.5935593 -1.9262829 0
+      vertex -2.9470472 -4.6438026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.5935593 -1.9262829 0
+      vertex -3.5058317 -4.2378225 0
+      vertex -1.8224211 -1.7113676 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.009327 -3.765009 0
+      vertex -1.8224211 -1.7113676 0
+      vertex -3.5058317 -4.2378225 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.8224211 -1.7113676 0
+      vertex -4.009327 -3.765009 0
+      vertex -2.022542 -1.4694624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.4495926 -3.2328186 0
+      vertex -2.022542 -1.4694624 0
+      vertex -4.009327 -3.765009 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.022542 -1.4694624 0
+      vertex -4.4495926 -3.2328186 0
+      vertex -2.1907663 -1.2043839 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.819686 -2.6496449 0
+      vertex -2.1907663 -1.2043839 0
+      vertex -4.4495926 -3.2328186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.819686 2.6496449 0
+      vertex 2.1907663 1.2043839 0
+      vertex 4.4495926 3.2328186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.022542 1.4694624 0
+      vertex 4.4495926 3.2328186 0
+      vertex 2.1907663 1.2043839 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.4495926 3.2328186 0
+      vertex 2.022542 1.4694624 0
+      vertex 4.009327 3.765009 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.8224211 1.7113676 0
+      vertex 4.009327 3.765009 0
+      vertex 2.022542 1.4694624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.009327 3.765009 0
+      vertex 1.8224211 1.7113676 0
+      vertex 3.5058317 4.2378225 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.5935593 1.9262829 0
+      vertex 3.5058317 4.2378225 0
+      vertex 1.8224211 1.7113676 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.5058317 4.2378225 0
+      vertex 1.5935593 1.9262829 0
+      vertex 2.9470472 4.6438026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.3395662 2.1108189 0
+      vertex 2.9470472 4.6438026 0
+      vertex 1.5935593 1.9262829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.9470472 4.6438026 0
+      vertex 1.3395662 2.1108189 0
+      vertex 2.3417854 4.976548 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.0644474 2.2620668 0
+      vertex 2.3417854 4.976548 0
+      vertex 1.3395662 2.1108189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.3417854 4.976548 0
+      vertex 1.0644474 2.2620668 0
+      vertex 1.6995926 5.23081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.772542 2.3776407 0
+      vertex 1.6995926 5.23081 0
+      vertex 1.0644474 2.2620668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.6995926 5.23081 0
+      vertex 0.772542 2.3776407 0
+      vertex 1.0305967 5.4025793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46845245 2.455718 0
+      vertex 1.0305967 5.4025793 0
+      vertex 0.772542 2.3776407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.46845245 2.455718 0
+      vertex 0.3453474 5.489146 0
+      vertex 1.0305967 5.4025793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.15697575 2.4950666 0
+      vertex 0.3453474 5.489146 0
+      vertex 0.46845245 2.455718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.15697575 2.4950666 0
+      vertex 0.3453474 5.489146 0
+      vertex 0.15697575 2.4950666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.15697575 2.4950666 0
+      vertex -0.3453474 5.489146 0
+      vertex 0.3453474 5.489146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46845245 2.455718 0
+      vertex -0.3453474 5.489146 0
+      vertex -0.15697575 2.4950666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0305967 5.4025793 0
+      vertex -0.46845245 2.455718 0
+      vertex -0.772542 2.3776407 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.46845245 2.455718 0
+      vertex -1.0305967 5.4025793 0
+      vertex -0.3453474 5.489146 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.6995926 5.23081 0
+      vertex -0.772542 2.3776407 0
+      vertex -1.0644474 2.2620668 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.3417854 4.976548 0
+      vertex -1.0644474 2.2620668 0
+      vertex -1.3395662 2.1108189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.9470472 4.6438026 0
+      vertex -1.3395662 2.1108189 0
+      vertex -1.5935593 1.9262829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.772542 2.3776407 0
+      vertex -1.6995926 5.23081 0
+      vertex -1.0305967 5.4025793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5058317 4.2378225 0
+      vertex -1.5935593 1.9262829 0
+      vertex -1.8224211 1.7113676 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.009327 3.765009 0
+      vertex -1.8224211 1.7113676 0
+      vertex -2.022542 1.4694624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.4495926 3.2328186 0
+      vertex -2.022542 1.4694624 0
+      vertex -2.1907663 1.2043839 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.819686 2.6496449 0
+      vertex -2.1907663 1.2043839 0
+      vertex -2.324441 0.920311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.0644474 2.2620668 0
+      vertex -2.3417854 4.976548 0
+      vertex -1.6995926 5.23081 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.1137705 2.024685 0
+      vertex -2.324441 0.920311 0
+      vertex -2.4214573 0.6217241 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.3272066 1.367794 0
+      vertex -2.4214573 0.6217241 0
+      vertex -2.4802866 0.31333256 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.4566307 0.689332 0
+      vertex -2.4802866 0.31333256 0
+      vertex -2.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.1907663 -1.2043839 0
+      vertex -4.819686 -2.6496449 0
+      vertex -2.324441 -0.920311 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.3395662 2.1108189 0
+      vertex -2.9470472 4.6438026 0
+      vertex -2.3417854 4.976548 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.1137705 -2.024685 0
+      vertex -2.324441 -0.920311 0
+      vertex -4.819686 -2.6496449 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.5935593 1.9262829 0
+      vertex -3.5058317 4.2378225 0
+      vertex -2.9470472 4.6438026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.324441 -0.920311 0
+      vertex -5.1137705 -2.024685 0
+      vertex -2.4214573 -0.6217241 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.8224211 1.7113676 0
+      vertex -4.009327 3.765009 0
+      vertex -3.5058317 4.2378225 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.3272066 -1.367794 0
+      vertex -2.4214573 -0.6217241 0
+      vertex -5.1137705 -2.024685 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.022542 1.4694624 0
+      vertex -4.4495926 3.2328186 0
+      vertex -4.009327 3.765009 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.4214573 -0.6217241 0
+      vertex -5.3272066 -1.367794 0
+      vertex -2.4802866 -0.31333256 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.1907663 1.2043839 0
+      vertex -4.819686 2.6496449 0
+      vertex -4.4495926 3.2328186 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.4566307 -0.689332 0
+      vertex -2.4802866 -0.31333256 0
+      vertex -5.3272066 -1.367794 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.324441 0.920311 0
+      vertex -5.1137705 2.024685 0
+      vertex -4.819686 2.6496449 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.4802866 -0.31333256 0
+      vertex -5.4566307 -0.689332 0
+      vertex -2.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.4214573 0.6217241 0
+      vertex -5.3272066 1.367794 0
+      vertex -5.1137705 2.024685 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.5 0 0
+      vertex -2.5 0 0
+      vertex -5.4566307 -0.689332 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.4802866 0.31333256 0
+      vertex -5.4566307 0.689332 0
+      vertex -5.3272066 1.367794 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.5 0 0
+      vertex -5.5 0 0
+      vertex -5.4566307 0.689332 0
+    endloop
+  endfacet
+  facet normal -0.9510568 -0.30901614 0
+    outer loop
+      vertex -5.1137705 -2.024685 0
+      vertex -5.3272066 -1.367794 10
+      vertex -5.3272066 -1.367794 0
+    endloop
+  endfacet
+  facet normal -0.9510568 -0.30901614 0
+    outer loop
+      vertex -5.3272066 -1.367794 10
+      vertex -5.1137705 -2.024685 0
+      vertex -5.1137705 -2.024685 10
+    endloop
+  endfacet
+  facet normal 0.90482664 -0.42578015 0
+    outer loop
+      vertex 4.819686 -2.6496449 10
+      vertex 5.1137705 -2.024685 0
+      vertex 5.1137705 -2.024685 10
+    endloop
+  endfacet
+  facet normal 0.90482664 -0.42578015 0
+    outer loop
+      vertex 5.1137705 -2.024685 0
+      vertex 4.819686 -2.6496449 10
+      vertex 4.819686 -2.6496449 0
+    endloop
+  endfacet
+  facet normal -0.12533295 0.9921147 0
+    outer loop
+      vertex -0.3453474 5.489146 0
+      vertex -1.0305967 5.4025793 10
+      vertex -0.3453474 5.489146 10
+    endloop
+  endfacet
+  facet normal -0.12533295 0.9921147 0
+    outer loop
+      vertex -1.0305967 5.4025793 10
+      vertex -0.3453474 5.489146 0
+      vertex -1.0305967 5.4025793 0
+    endloop
+  endfacet
+  facet normal 0.6845472 -0.72896856 0
+    outer loop
+      vertex 3.5058317 -4.2378225 0
+      vertex 4.009327 -3.765009 10
+      vertex 3.5058317 -4.2378225 10
+    endloop
+  endfacet
+  facet normal 0.6845472 -0.72896856 0
+    outer loop
+      vertex 4.009327 -3.765009 10
+      vertex 3.5058317 -4.2378225 0
+      vertex 4.009327 -3.765009 0
+    endloop
+  endfacet
+  facet normal 0.7705136 -0.6374236 0
+    outer loop
+      vertex 4.009327 -3.765009 10
+      vertex 4.4495926 -3.2328186 0
+      vertex 4.4495926 -3.2328186 10
+    endloop
+  endfacet
+  facet normal 0.7705136 -0.6374236 0
+    outer loop
+      vertex 4.4495926 -3.2328186 0
+      vertex 4.009327 -3.765009 10
+      vertex 4.009327 -3.765009 0
+    endloop
+  endfacet
+  facet normal -0.9980267 0.0627908 0
+    outer loop
+      vertex -5.5 0 0
+      vertex -5.4566307 0.689332 10
+      vertex -5.4566307 0.689332 0
+    endloop
+  endfacet
+  facet normal -0.9980267 0.0627908 0
+    outer loop
+      vertex -5.4566307 0.689332 10
+      vertex -5.5 0 0
+      vertex -5.5 0 10
+    endloop
+  endfacet
+  facet normal -0.8443279 0.5358268 0
+    outer loop
+      vertex -4.819686 2.6496449 0
+      vertex -4.4495926 3.2328186 10
+      vertex -4.4495926 3.2328186 0
+    endloop
+  endfacet
+  facet normal -0.8443279 0.5358268 0
+    outer loop
+      vertex -4.4495926 3.2328186 10
+      vertex -4.819686 2.6496449 0
+      vertex -4.819686 2.6496449 10
+    endloop
+  endfacet
+  facet normal -0.6845472 -0.72896856 0
+    outer loop
+      vertex -4.009327 -3.765009 0
+      vertex -3.5058317 -4.2378225 10
+      vertex -4.009327 -3.765009 10
+    endloop
+  endfacet
+  facet normal -0.6845472 -0.72896856 0
+    outer loop
+      vertex -3.5058317 -4.2378225 10
+      vertex -4.009327 -3.765009 0
+      vertex -3.5058317 -4.2378225 0
+    endloop
+  endfacet
+  facet normal -0.9822871 -0.18738207 0
+    outer loop
+      vertex -5.3272066 -1.367794 0
+      vertex -5.4566307 -0.689332 10
+      vertex -5.4566307 -0.689332 0
+    endloop
+  endfacet
+  facet normal -0.9822871 -0.18738207 0
+    outer loop
+      vertex -5.4566307 -0.689332 10
+      vertex -5.3272066 -1.367794 0
+      vertex -5.3272066 -1.367794 10
+    endloop
+  endfacet
+  facet normal 0.48175374 0.87630665 0
+    outer loop
+      vertex 2.9470472 4.6438026 0
+      vertex 2.3417854 4.976548 10
+      vertex 2.9470472 4.6438026 10
+    endloop
+  endfacet
+  facet normal 0.48175374 0.87630665 0
+    outer loop
+      vertex 2.3417854 4.976548 10
+      vertex 2.9470472 4.6438026 0
+      vertex 2.3417854 4.976548 0
+    endloop
+  endfacet
+  facet normal 0.9510568 0.30901614 0
+    outer loop
+      vertex 5.3272066 1.367794 10
+      vertex 5.1137705 2.024685 0
+      vertex 5.1137705 2.024685 10
+    endloop
+  endfacet
+  facet normal 0.9510568 0.30901614 0
+    outer loop
+      vertex 5.1137705 2.024685 0
+      vertex 5.3272066 1.367794 10
+      vertex 5.3272066 1.367794 0
+    endloop
+  endfacet
+  facet normal -0.48175374 0.87630665 0
+    outer loop
+      vertex -2.3417854 4.976548 0
+      vertex -2.9470472 4.6438026 10
+      vertex -2.3417854 4.976548 10
+    endloop
+  endfacet
+  facet normal -0.48175374 0.87630665 0
+    outer loop
+      vertex -2.9470472 4.6438026 10
+      vertex -2.3417854 4.976548 0
+      vertex -2.9470472 4.6438026 0
+    endloop
+  endfacet
+  facet normal -0.9822871 0.18738207 0
+    outer loop
+      vertex -5.4566307 0.689332 0
+      vertex -5.3272066 1.367794 10
+      vertex -5.3272066 1.367794 0
+    endloop
+  endfacet
+  facet normal -0.9822871 0.18738207 0
+    outer loop
+      vertex -5.3272066 1.367794 10
+      vertex -5.4566307 0.689332 0
+      vertex -5.4566307 0.689332 10
+    endloop
+  endfacet
+  facet normal 0.24869016 -0.9685831 0
+    outer loop
+      vertex 1.0305967 -5.4025793 0
+      vertex 1.6995926 -5.23081 10
+      vertex 1.0305967 -5.4025793 10
+    endloop
+  endfacet
+  facet normal 0.24869016 -0.9685831 0
+    outer loop
+      vertex 1.6995926 -5.23081 10
+      vertex 1.0305967 -5.4025793 0
+      vertex 1.6995926 -5.23081 0
+    endloop
+  endfacet
+  facet normal 0.7705136 0.6374236 0
+    outer loop
+      vertex 4.4495926 3.2328186 10
+      vertex 4.009327 3.765009 0
+      vertex 4.009327 3.765009 10
+    endloop
+  endfacet
+  facet normal 0.7705136 0.6374236 0
+    outer loop
+      vertex 4.009327 3.765009 0
+      vertex 4.4495926 3.2328186 10
+      vertex 4.4495926 3.2328186 0
+    endloop
+  endfacet
+  facet normal -0.36812434 -0.92977655 0
+    outer loop
+      vertex -2.3417854 -4.976548 0
+      vertex -1.6995926 -5.23081 10
+      vertex -2.3417854 -4.976548 10
+    endloop
+  endfacet
+  facet normal -0.36812434 -0.92977655 0
+    outer loop
+      vertex -1.6995926 -5.23081 10
+      vertex -2.3417854 -4.976548 0
+      vertex -1.6995926 -5.23081 0
+    endloop
+  endfacet
+  facet normal 0.36812434 -0.92977655 0
+    outer loop
+      vertex 1.6995926 -5.23081 0
+      vertex 2.3417854 -4.976548 10
+      vertex 1.6995926 -5.23081 10
+    endloop
+  endfacet
+  facet normal 0.36812434 -0.92977655 0
+    outer loop
+      vertex 2.3417854 -4.976548 10
+      vertex 1.6995926 -5.23081 0
+      vertex 2.3417854 -4.976548 0
+    endloop
+  endfacet
+  facet normal 0.12533295 0.9921147 0
+    outer loop
+      vertex 1.0305967 5.4025793 0
+      vertex 0.3453474 5.489146 10
+      vertex 1.0305967 5.4025793 10
+    endloop
+  endfacet
+  facet normal 0.12533295 0.9921147 0
+    outer loop
+      vertex 0.3453474 5.489146 10
+      vertex 1.0305967 5.4025793 0
+      vertex 0.3453474 5.489146 0
+    endloop
+  endfacet
+  facet normal -0.5877847 -0.8090174 0
+    outer loop
+      vertex -3.5058317 -4.2378225 0
+      vertex -2.9470472 -4.6438026 10
+      vertex -3.5058317 -4.2378225 10
+    endloop
+  endfacet
+  facet normal -0.5877847 -0.8090174 0
+    outer loop
+      vertex -2.9470472 -4.6438026 10
+      vertex -3.5058317 -4.2378225 0
+      vertex -2.9470472 -4.6438026 0
+    endloop
+  endfacet
+  facet normal 0.90482664 0.42578015 0
+    outer loop
+      vertex 5.1137705 2.024685 10
+      vertex 4.819686 2.6496449 0
+      vertex 4.819686 2.6496449 10
+    endloop
+  endfacet
+  facet normal 0.90482664 0.42578015 0
+    outer loop
+      vertex 4.819686 2.6496449 0
+      vertex 5.1137705 2.024685 10
+      vertex 5.1137705 2.024685 0
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -0.156976 2.49507 0
-      vertex 0.156976 2.49507 10
-      vertex -0.156976 2.49507 10
+      vertex -0.3453474 -5.489146 0
+      vertex 0.3453474 -5.489146 10
+      vertex -0.3453474 -5.489146 10
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 -1 0
     outer loop
-      vertex 0.156976 2.49507 10
-      vertex -0.156976 2.49507 0
-      vertex 0.156976 2.49507 0
+      vertex 0.3453474 -5.489146 10
+      vertex -0.3453474 -5.489146 0
+      vertex 0.3453474 -5.489146 0
     endloop
   endfacet
-  facet normal -0.481757 0.876305 0
+  facet normal -0.12533295 -0.9921147 0
     outer loop
-      vertex 1.33957 -2.11082 0
-      vertex 1.06445 -2.26207 10
-      vertex 1.33957 -2.11082 10
+      vertex -1.0305967 -5.4025793 0
+      vertex -0.3453474 -5.489146 10
+      vertex -1.0305967 -5.4025793 10
     endloop
   endfacet
-  facet normal -0.481757 0.876305 0
+  facet normal -0.12533295 -0.9921147 0
     outer loop
-      vertex 1.06445 -2.26207 10
-      vertex 1.33957 -2.11082 0
-      vertex 1.06445 -2.26207 0
+      vertex -0.3453474 -5.489146 10
+      vertex -1.0305967 -5.4025793 0
+      vertex -0.3453474 -5.489146 0
     endloop
   endfacet
-  facet normal 0.90483 -0.425772 0
+  facet normal 0.36812434 0.92977655 0
     outer loop
-      vertex -2.32444 0.920311 10
-      vertex -2.19077 1.20438 0
-      vertex -2.19077 1.20438 10
+      vertex 2.3417854 4.976548 0
+      vertex 1.6995926 5.23081 10
+      vertex 2.3417854 4.976548 10
     endloop
   endfacet
-  facet normal 0.90483 -0.425772 0
+  facet normal 0.36812434 0.92977655 0
     outer loop
-      vertex -2.19077 1.20438 0
-      vertex -2.32444 0.920311 10
-      vertex -2.32444 0.920311 0
+      vertex 1.6995926 5.23081 10
+      vertex 2.3417854 4.976548 0
+      vertex 1.6995926 5.23081 0
     endloop
   endfacet
-  facet normal 0.770522 -0.637414 0
+  facet normal -0.90482664 -0.42578015 0
     outer loop
-      vertex -2.02254 1.46946 10
-      vertex -1.82242 1.71137 0
-      vertex -1.82242 1.71137 10
+      vertex -4.819686 -2.6496449 0
+      vertex -5.1137705 -2.024685 10
+      vertex -5.1137705 -2.024685 0
     endloop
   endfacet
-  facet normal 0.770522 -0.637414 0
+  facet normal -0.90482664 -0.42578015 0
     outer loop
-      vertex -1.82242 1.71137 0
-      vertex -2.02254 1.46946 10
-      vertex -2.02254 1.46946 0
+      vertex -5.1137705 -2.024685 10
+      vertex -4.819686 -2.6496449 0
+      vertex -4.819686 -2.6496449 10
+    endloop
+  endfacet
+  facet normal -0.24869016 -0.9685831 0
+    outer loop
+      vertex -1.6995926 -5.23081 0
+      vertex -1.0305967 -5.4025793 10
+      vertex -1.6995926 -5.23081 10
+    endloop
+  endfacet
+  facet normal -0.24869016 -0.9685831 0
+    outer loop
+      vertex -1.0305967 -5.4025793 10
+      vertex -1.6995926 -5.23081 0
+      vertex -1.0305967 -5.4025793 0
+    endloop
+  endfacet
+  facet normal 0.9822871 -0.18738207 0
+    outer loop
+      vertex 5.3272066 -1.367794 10
+      vertex 5.4566307 -0.689332 0
+      vertex 5.4566307 -0.689332 10
+    endloop
+  endfacet
+  facet normal 0.9822871 -0.18738207 0
+    outer loop
+      vertex 5.4566307 -0.689332 0
+      vertex 5.3272066 -1.367794 10
+      vertex 5.3272066 -1.367794 0
+    endloop
+  endfacet
+  facet normal -0.48175374 -0.87630665 0
+    outer loop
+      vertex -2.9470472 -4.6438026 0
+      vertex -2.3417854 -4.976548 10
+      vertex -2.9470472 -4.6438026 10
+    endloop
+  endfacet
+  facet normal -0.48175374 -0.87630665 0
+    outer loop
+      vertex -2.3417854 -4.976548 10
+      vertex -2.9470472 -4.6438026 0
+      vertex -2.3417854 -4.976548 0
+    endloop
+  endfacet
+  facet normal -0.90482664 0.42578015 0
+    outer loop
+      vertex -5.1137705 2.024685 0
+      vertex -4.819686 2.6496449 10
+      vertex -4.819686 2.6496449 0
+    endloop
+  endfacet
+  facet normal -0.90482664 0.42578015 0
+    outer loop
+      vertex -4.819686 2.6496449 10
+      vertex -5.1137705 2.024685 0
+      vertex -5.1137705 2.024685 10
+    endloop
+  endfacet
+  facet normal 0.12533295 -0.9921147 0
+    outer loop
+      vertex 0.3453474 -5.489146 0
+      vertex 1.0305967 -5.4025793 10
+      vertex 0.3453474 -5.489146 10
+    endloop
+  endfacet
+  facet normal 0.12533295 -0.9921147 0
+    outer loop
+      vertex 1.0305967 -5.4025793 10
+      vertex 0.3453474 -5.489146 0
+      vertex 1.0305967 -5.4025793 0
+    endloop
+  endfacet
+  facet normal 0.48175374 -0.87630665 0
+    outer loop
+      vertex 2.3417854 -4.976548 0
+      vertex 2.9470472 -4.6438026 10
+      vertex 2.3417854 -4.976548 10
+    endloop
+  endfacet
+  facet normal 0.48175374 -0.87630665 0
+    outer loop
+      vertex 2.9470472 -4.6438026 10
+      vertex 2.3417854 -4.976548 0
+      vertex 2.9470472 -4.6438026 0
+    endloop
+  endfacet
+  facet normal 0.5877847 -0.8090174 0
+    outer loop
+      vertex 2.9470472 -4.6438026 0
+      vertex 3.5058317 -4.2378225 10
+      vertex 2.9470472 -4.6438026 10
+    endloop
+  endfacet
+  facet normal 0.5877847 -0.8090174 0
+    outer loop
+      vertex 3.5058317 -4.2378225 10
+      vertex 2.9470472 -4.6438026 0
+      vertex 3.5058317 -4.2378225 0
+    endloop
+  endfacet
+  facet normal -0.24869016 0.9685831 0
+    outer loop
+      vertex -1.0305967 5.4025793 0
+      vertex -1.6995926 5.23081 10
+      vertex -1.0305967 5.4025793 10
+    endloop
+  endfacet
+  facet normal -0.24869016 0.9685831 0
+    outer loop
+      vertex -1.6995926 5.23081 10
+      vertex -1.0305967 5.4025793 0
+      vertex -1.6995926 5.23081 0
+    endloop
+  endfacet
+  facet normal -0.99802667 -0.06279112 0
+    outer loop
+      vertex 2.5 0 0
+      vertex 2.4802866 0.31333256 10
+      vertex 2.4802866 0.31333256 0
+    endloop
+  endfacet
+  facet normal -0.99802667 -0.06279112 0
+    outer loop
+      vertex 2.4802866 0.31333256 10
+      vertex 2.5 0 0
+      vertex 2.5 0 10
+    endloop
+  endfacet
+  facet normal 0.8443274 -0.53582764 0
+    outer loop
+      vertex -2.1907663 1.2043839 10
+      vertex -2.022542 1.4694624 0
+      vertex -2.022542 1.4694624 10
+    endloop
+  endfacet
+  facet normal 0.8443274 -0.53582764 0
+    outer loop
+      vertex -2.022542 1.4694624 0
+      vertex -2.1907663 1.2043839 10
+      vertex -2.1907663 1.2043839 0
+    endloop
+  endfacet
+  facet normal 0.68454665 0.72896904 0
+    outer loop
+      vertex -1.5935593 -1.9262829 0
+      vertex -1.8224211 -1.7113676 10
+      vertex -1.5935593 -1.9262829 10
+    endloop
+  endfacet
+  facet normal 0.68454665 0.72896904 0
+    outer loop
+      vertex -1.8224211 -1.7113676 10
+      vertex -1.5935593 -1.9262829 0
+      vertex -1.8224211 -1.7113676 0
+    endloop
+  endfacet
+  facet normal -0.77051395 0.6374231 0
+    outer loop
+      vertex 1.8224211 -1.7113676 0
+      vertex 2.022542 -1.4694624 10
+      vertex 2.022542 -1.4694624 0
+    endloop
+  endfacet
+  facet normal -0.77051395 0.6374231 0
+    outer loop
+      vertex 2.022542 -1.4694624 10
+      vertex 1.8224211 -1.7113676 0
+      vertex 1.8224211 -1.7113676 10
+    endloop
+  endfacet
+  facet normal 0.982287 -0.18738276 0
+    outer loop
+      vertex -2.4802866 0.31333256 10
+      vertex -2.4214573 0.6217241 0
+      vertex -2.4214573 0.6217241 10
+    endloop
+  endfacet
+  facet normal 0.982287 -0.18738276 0
+    outer loop
+      vertex -2.4214573 0.6217241 0
+      vertex -2.4802866 0.31333256 10
+      vertex -2.4802866 0.31333256 0
+    endloop
+  endfacet
+  facet normal -0.5877837 0.80901814 0
+    outer loop
+      vertex 1.5935593 -1.9262829 0
+      vertex 1.3395662 -2.1108189 10
+      vertex 1.5935593 -1.9262829 10
+    endloop
+  endfacet
+  facet normal -0.5877837 0.80901814 0
+    outer loop
+      vertex 1.3395662 -2.1108189 10
+      vertex 1.5935593 -1.9262829 0
+      vertex 1.3395662 -2.1108189 0
+    endloop
+  endfacet
+  facet normal 0.99802667 -0.06279112 0
+    outer loop
+      vertex -2.5 0 10
+      vertex -2.4802866 0.31333256 0
+      vertex -2.4802866 0.31333256 10
+    endloop
+  endfacet
+  facet normal 0.99802667 -0.06279112 0
+    outer loop
+      vertex -2.4802866 0.31333256 0
+      vertex -2.5 0 10
+      vertex -2.5 0 0
+    endloop
+  endfacet
+  facet normal -0.68454665 0.72896904 0
+    outer loop
+      vertex 1.8224211 -1.7113676 0
+      vertex 1.5935593 -1.9262829 10
+      vertex 1.8224211 -1.7113676 10
+    endloop
+  endfacet
+  facet normal -0.68454665 0.72896904 0
+    outer loop
+      vertex 1.5935593 -1.9262829 10
+      vertex 1.8224211 -1.7113676 0
+      vertex 1.5935593 -1.9262829 0
+    endloop
+  endfacet
+  facet normal -0.77051395 -0.6374231 0
+    outer loop
+      vertex 2.022542 1.4694624 0
+      vertex 1.8224211 1.7113676 10
+      vertex 1.8224211 1.7113676 0
+    endloop
+  endfacet
+  facet normal -0.77051395 -0.6374231 0
+    outer loop
+      vertex 1.8224211 1.7113676 10
+      vertex 2.022542 1.4694624 0
+      vertex 2.022542 1.4694624 10
+    endloop
+  endfacet
+  facet normal -0.9510569 0.3090158 0
+    outer loop
+      vertex 2.324441 -0.920311 0
+      vertex 2.4214573 -0.6217241 10
+      vertex 2.4214573 -0.6217241 0
+    endloop
+  endfacet
+  facet normal -0.9510569 0.3090158 0
+    outer loop
+      vertex 2.4214573 -0.6217241 10
+      vertex 2.324441 -0.920311 0
+      vertex 2.324441 -0.920311 10
+    endloop
+  endfacet
+  facet normal -0.24869105 0.96858287 0
+    outer loop
+      vertex 0.772542 -2.3776407 0
+      vertex 0.46845245 -2.455718 10
+      vertex 0.772542 -2.3776407 10
+    endloop
+  endfacet
+  facet normal -0.24869105 0.96858287 0
+    outer loop
+      vertex 0.46845245 -2.455718 10
+      vertex 0.772542 -2.3776407 0
+      vertex 0.46845245 -2.455718 0
+    endloop
+  endfacet
+  facet normal 0.9510569 -0.3090158 0
+    outer loop
+      vertex -2.4214573 0.6217241 10
+      vertex -2.324441 0.920311 0
+      vertex -2.324441 0.920311 10
+    endloop
+  endfacet
+  facet normal 0.9510569 -0.3090158 0
+    outer loop
+      vertex -2.324441 0.920311 0
+      vertex -2.4214573 0.6217241 10
+      vertex -2.4214573 0.6217241 0
+    endloop
+  endfacet
+  facet normal -0.99802667 0.06279112 0
+    outer loop
+      vertex 2.4802866 -0.31333256 0
+      vertex 2.5 0 10
+      vertex 2.5 0 0
+    endloop
+  endfacet
+  facet normal -0.99802667 0.06279112 0
+    outer loop
+      vertex 2.5 0 10
+      vertex 2.4802866 -0.31333256 0
+      vertex 2.4802866 -0.31333256 10
+    endloop
+  endfacet
+  facet normal 0.90482694 0.4257795 0
+    outer loop
+      vertex -2.1907663 -1.2043839 10
+      vertex -2.324441 -0.920311 0
+      vertex -2.324441 -0.920311 10
+    endloop
+  endfacet
+  facet normal 0.90482694 0.4257795 0
+    outer loop
+      vertex -2.324441 -0.920311 0
+      vertex -2.1907663 -1.2043839 10
+      vertex -2.1907663 -1.2043839 0
+    endloop
+  endfacet
+  facet normal 0.36812553 -0.9297761 0
+    outer loop
+      vertex -1.0644474 2.2620668 0
+      vertex -0.772542 2.3776407 10
+      vertex -1.0644474 2.2620668 10
+    endloop
+  endfacet
+  facet normal 0.36812553 -0.9297761 0
+    outer loop
+      vertex -0.772542 2.3776407 10
+      vertex -1.0644474 2.2620668 0
+      vertex -0.772542 2.3776407 0
+    endloop
+  endfacet
+  facet normal -0.48175398 -0.87630653 0
+    outer loop
+      vertex 1.0644474 2.2620668 0
+      vertex 1.3395662 2.1108189 10
+      vertex 1.0644474 2.2620668 10
+    endloop
+  endfacet
+  facet normal -0.48175398 -0.87630653 0
+    outer loop
+      vertex 1.3395662 2.1108189 10
+      vertex 1.0644474 2.2620668 0
+      vertex 1.3395662 2.1108189 0
+    endloop
+  endfacet
+  facet normal 0.90482694 -0.4257795 0
+    outer loop
+      vertex -2.324441 0.920311 10
+      vertex -2.1907663 1.2043839 0
+      vertex -2.1907663 1.2043839 10
+    endloop
+  endfacet
+  facet normal 0.90482694 -0.4257795 0
+    outer loop
+      vertex -2.1907663 1.2043839 0
+      vertex -2.324441 0.920311 10
+      vertex -2.324441 0.920311 0
+    endloop
+  endfacet
+  facet normal -0.36812553 -0.9297761 0
+    outer loop
+      vertex 0.772542 2.3776407 0
+      vertex 1.0644474 2.2620668 10
+      vertex 0.772542 2.3776407 10
+    endloop
+  endfacet
+  facet normal -0.36812553 -0.9297761 0
+    outer loop
+      vertex 1.0644474 2.2620668 10
+      vertex 0.772542 2.3776407 0
+      vertex 1.0644474 2.2620668 0
+    endloop
+  endfacet
+  facet normal 0.77051395 -0.6374231 0
+    outer loop
+      vertex -2.022542 1.4694624 10
+      vertex -1.8224211 1.7113676 0
+      vertex -1.8224211 1.7113676 10
+    endloop
+  endfacet
+  facet normal 0.77051395 -0.6374231 0
+    outer loop
+      vertex -1.8224211 1.7113676 0
+      vertex -2.022542 1.4694624 10
+      vertex -2.022542 1.4694624 0
+    endloop
+  endfacet
+  facet normal 0.9510569 0.3090158 0
+    outer loop
+      vertex -2.324441 -0.920311 10
+      vertex -2.4214573 -0.6217241 0
+      vertex -2.4214573 -0.6217241 10
+    endloop
+  endfacet
+  facet normal 0.9510569 0.3090158 0
+    outer loop
+      vertex -2.4214573 -0.6217241 0
+      vertex -2.324441 -0.920311 10
+      vertex -2.324441 -0.920311 0
+    endloop
+  endfacet
+  facet normal -0.9510569 -0.3090158 0
+    outer loop
+      vertex 2.4214573 0.6217241 0
+      vertex 2.324441 0.920311 10
+      vertex 2.324441 0.920311 0
+    endloop
+  endfacet
+  facet normal -0.9510569 -0.3090158 0
+    outer loop
+      vertex 2.324441 0.920311 10
+      vertex 2.4214573 0.6217241 0
+      vertex 2.4214573 0.6217241 10
+    endloop
+  endfacet
+  facet normal 0.36812553 0.9297761 0
+    outer loop
+      vertex -0.772542 -2.3776407 0
+      vertex -1.0644474 -2.2620668 10
+      vertex -0.772542 -2.3776407 10
+    endloop
+  endfacet
+  facet normal 0.36812553 0.9297761 0
+    outer loop
+      vertex -1.0644474 -2.2620668 10
+      vertex -0.772542 -2.3776407 0
+      vertex -1.0644474 -2.2620668 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.15697575 2.4950666 0
+      vertex 0.15697575 2.4950666 10
+      vertex -0.15697575 2.4950666 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.15697575 2.4950666 10
+      vertex -0.15697575 2.4950666 0
+      vertex 0.15697575 2.4950666 0
+    endloop
+  endfacet
+  facet normal -0.982287 -0.18738276 0
+    outer loop
+      vertex 2.4802866 0.31333256 0
+      vertex 2.4214573 0.6217241 10
+      vertex 2.4214573 0.6217241 0
+    endloop
+  endfacet
+  facet normal -0.982287 -0.18738276 0
+    outer loop
+      vertex 2.4214573 0.6217241 10
+      vertex 2.4802866 0.31333256 0
+      vertex 2.4802866 0.31333256 10
+    endloop
+  endfacet
+  facet normal -0.90482694 -0.4257795 0
+    outer loop
+      vertex 2.324441 0.920311 0
+      vertex 2.1907663 1.2043839 10
+      vertex 2.1907663 1.2043839 0
+    endloop
+  endfacet
+  facet normal -0.90482694 -0.4257795 0
+    outer loop
+      vertex 2.1907663 1.2043839 10
+      vertex 2.324441 0.920311 0
+      vertex 2.324441 0.920311 10
+    endloop
+  endfacet
+  facet normal -0.68454665 -0.72896904 0
+    outer loop
+      vertex 1.5935593 1.9262829 0
+      vertex 1.8224211 1.7113676 10
+      vertex 1.5935593 1.9262829 10
+    endloop
+  endfacet
+  facet normal -0.68454665 -0.72896904 0
+    outer loop
+      vertex 1.8224211 1.7113676 10
+      vertex 1.5935593 1.9262829 0
+      vertex 1.8224211 1.7113676 0
+    endloop
+  endfacet
+  facet normal 0.77051395 0.6374231 0
+    outer loop
+      vertex -1.8224211 -1.7113676 10
+      vertex -2.022542 -1.4694624 0
+      vertex -2.022542 -1.4694624 10
+    endloop
+  endfacet
+  facet normal 0.77051395 0.6374231 0
+    outer loop
+      vertex -2.022542 -1.4694624 0
+      vertex -1.8224211 -1.7113676 10
+      vertex -1.8224211 -1.7113676 0
+    endloop
+  endfacet
+  facet normal -0.8443274 0.53582764 0
+    outer loop
+      vertex 2.022542 -1.4694624 0
+      vertex 2.1907663 -1.2043839 10
+      vertex 2.1907663 -1.2043839 0
+    endloop
+  endfacet
+  facet normal -0.8443274 0.53582764 0
+    outer loop
+      vertex 2.1907663 -1.2043839 10
+      vertex 2.022542 -1.4694624 0
+      vertex 2.022542 -1.4694624 10
+    endloop
+  endfacet
+  facet normal -0.90482694 0.4257795 0
+    outer loop
+      vertex 2.1907663 -1.2043839 0
+      vertex 2.324441 -0.920311 10
+      vertex 2.324441 -0.920311 0
+    endloop
+  endfacet
+  facet normal -0.90482694 0.4257795 0
+    outer loop
+      vertex 2.324441 -0.920311 10
+      vertex 2.1907663 -1.2043839 0
+      vertex 2.1907663 -1.2043839 10
+    endloop
+  endfacet
+  facet normal 0.48175398 -0.87630653 0
+    outer loop
+      vertex -1.3395662 2.1108189 0
+      vertex -1.0644474 2.2620668 10
+      vertex -1.3395662 2.1108189 10
+    endloop
+  endfacet
+  facet normal 0.48175398 -0.87630653 0
+    outer loop
+      vertex -1.0644474 2.2620668 10
+      vertex -1.3395662 2.1108189 0
+      vertex -1.0644474 2.2620668 0
+    endloop
+  endfacet
+  facet normal 0.982287 0.18738276 0
+    outer loop
+      vertex -2.4214573 -0.6217241 10
+      vertex -2.4802866 -0.31333256 0
+      vertex -2.4802866 -0.31333256 10
+    endloop
+  endfacet
+  facet normal 0.982287 0.18738276 0
+    outer loop
+      vertex -2.4802866 -0.31333256 0
+      vertex -2.4214573 -0.6217241 10
+      vertex -2.4214573 -0.6217241 0
+    endloop
+  endfacet
+  facet normal 0.99802667 0.06279112 0
+    outer loop
+      vertex -2.4802866 -0.31333256 10
+      vertex -2.5 0 0
+      vertex -2.5 0 10
+    endloop
+  endfacet
+  facet normal 0.99802667 0.06279112 0
+    outer loop
+      vertex -2.5 0 0
+      vertex -2.4802866 -0.31333256 10
+      vertex -2.4802866 -0.31333256 0
+    endloop
+  endfacet
+  facet normal -0.5877837 -0.80901814 0
+    outer loop
+      vertex 1.3395662 2.1108189 0
+      vertex 1.5935593 1.9262829 10
+      vertex 1.3395662 2.1108189 10
+    endloop
+  endfacet
+  facet normal -0.5877837 -0.80901814 0
+    outer loop
+      vertex 1.5935593 1.9262829 10
+      vertex 1.3395662 2.1108189 0
+      vertex 1.5935593 1.9262829 0
+    endloop
+  endfacet
+  facet normal -0.12533306 0.9921147 0
+    outer loop
+      vertex 0.46845245 -2.455718 0
+      vertex 0.15697575 -2.4950666 10
+      vertex 0.46845245 -2.455718 10
+    endloop
+  endfacet
+  facet normal -0.12533306 0.9921147 0
+    outer loop
+      vertex 0.15697575 -2.4950666 10
+      vertex 0.46845245 -2.455718 0
+      vertex 0.15697575 -2.4950666 0
+    endloop
+  endfacet
+  facet normal 0.68454665 -0.72896904 0
+    outer loop
+      vertex -1.8224211 1.7113676 0
+      vertex -1.5935593 1.9262829 10
+      vertex -1.8224211 1.7113676 10
+    endloop
+  endfacet
+  facet normal 0.68454665 -0.72896904 0
+    outer loop
+      vertex -1.5935593 1.9262829 10
+      vertex -1.8224211 1.7113676 0
+      vertex -1.5935593 1.9262829 0
+    endloop
+  endfacet
+  facet normal 0.5877837 -0.80901814 0
+    outer loop
+      vertex -1.5935593 1.9262829 0
+      vertex -1.3395662 2.1108189 10
+      vertex -1.5935593 1.9262829 10
+    endloop
+  endfacet
+  facet normal 0.5877837 -0.80901814 0
+    outer loop
+      vertex -1.3395662 2.1108189 10
+      vertex -1.5935593 1.9262829 0
+      vertex -1.3395662 2.1108189 0
+    endloop
+  endfacet
+  facet normal -0.982287 0.18738276 0
+    outer loop
+      vertex 2.4214573 -0.6217241 0
+      vertex 2.4802866 -0.31333256 10
+      vertex 2.4802866 -0.31333256 0
+    endloop
+  endfacet
+  facet normal -0.982287 0.18738276 0
+    outer loop
+      vertex 2.4802866 -0.31333256 10
+      vertex 2.4214573 -0.6217241 0
+      vertex 2.4214573 -0.6217241 10
+    endloop
+  endfacet
+  facet normal 0.5877837 0.80901814 0
+    outer loop
+      vertex -1.3395662 -2.1108189 0
+      vertex -1.5935593 -1.9262829 10
+      vertex -1.3395662 -2.1108189 10
+    endloop
+  endfacet
+  facet normal 0.5877837 0.80901814 0
+    outer loop
+      vertex -1.5935593 -1.9262829 10
+      vertex -1.3395662 -2.1108189 0
+      vertex -1.5935593 -1.9262829 0
+    endloop
+  endfacet
+  facet normal 0.24869105 -0.96858287 0
+    outer loop
+      vertex -0.772542 2.3776407 0
+      vertex -0.46845245 2.455718 10
+      vertex -0.772542 2.3776407 10
+    endloop
+  endfacet
+  facet normal 0.24869105 -0.96858287 0
+    outer loop
+      vertex -0.46845245 2.455718 10
+      vertex -0.772542 2.3776407 0
+      vertex -0.46845245 2.455718 0
+    endloop
+  endfacet
+  facet normal -0.24869105 -0.96858287 0
+    outer loop
+      vertex 0.46845245 2.455718 0
+      vertex 0.772542 2.3776407 10
+      vertex 0.46845245 2.455718 10
+    endloop
+  endfacet
+  facet normal -0.24869105 -0.96858287 0
+    outer loop
+      vertex 0.772542 2.3776407 10
+      vertex 0.46845245 2.455718 0
+      vertex 0.772542 2.3776407 0
+    endloop
+  endfacet
+  facet normal -0.12533306 -0.9921147 0
+    outer loop
+      vertex 0.15697575 2.4950666 0
+      vertex 0.46845245 2.455718 10
+      vertex 0.15697575 2.4950666 10
+    endloop
+  endfacet
+  facet normal -0.12533306 -0.9921147 0
+    outer loop
+      vertex 0.46845245 2.455718 10
+      vertex 0.15697575 2.4950666 0
+      vertex 0.46845245 2.455718 0
+    endloop
+  endfacet
+  facet normal 0.12533306 -0.9921147 0
+    outer loop
+      vertex -0.46845245 2.455718 0
+      vertex -0.15697575 2.4950666 10
+      vertex -0.46845245 2.455718 10
+    endloop
+  endfacet
+  facet normal 0.12533306 -0.9921147 0
+    outer loop
+      vertex -0.15697575 2.4950666 10
+      vertex -0.46845245 2.455718 0
+      vertex -0.15697575 2.4950666 0
+    endloop
+  endfacet
+  facet normal 0.8443274 0.53582764 0
+    outer loop
+      vertex -2.022542 -1.4694624 10
+      vertex -2.1907663 -1.2043839 0
+      vertex -2.1907663 -1.2043839 10
+    endloop
+  endfacet
+  facet normal 0.8443274 0.53582764 0
+    outer loop
+      vertex -2.1907663 -1.2043839 0
+      vertex -2.022542 -1.4694624 10
+      vertex -2.022542 -1.4694624 0
+    endloop
+  endfacet
+  facet normal -0.8443274 -0.53582764 0
+    outer loop
+      vertex 2.1907663 1.2043839 0
+      vertex 2.022542 1.4694624 10
+      vertex 2.022542 1.4694624 0
+    endloop
+  endfacet
+  facet normal -0.8443274 -0.53582764 0
+    outer loop
+      vertex 2.022542 1.4694624 10
+      vertex 2.1907663 1.2043839 0
+      vertex 2.1907663 1.2043839 10
+    endloop
+  endfacet
+  facet normal -0.48175398 0.87630653 0
+    outer loop
+      vertex 1.3395662 -2.1108189 0
+      vertex 1.0644474 -2.2620668 10
+      vertex 1.3395662 -2.1108189 10
+    endloop
+  endfacet
+  facet normal -0.48175398 0.87630653 0
+    outer loop
+      vertex 1.0644474 -2.2620668 10
+      vertex 1.3395662 -2.1108189 0
+      vertex 1.0644474 -2.2620668 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.15697575 -2.4950666 0
+      vertex -0.15697575 -2.4950666 10
+      vertex 0.15697575 -2.4950666 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.15697575 -2.4950666 10
+      vertex 0.15697575 -2.4950666 0
+      vertex -0.15697575 -2.4950666 0
+    endloop
+  endfacet
+  facet normal 0.48175398 0.87630653 0
+    outer loop
+      vertex -1.0644474 -2.2620668 0
+      vertex -1.3395662 -2.1108189 10
+      vertex -1.0644474 -2.2620668 10
+    endloop
+  endfacet
+  facet normal 0.48175398 0.87630653 0
+    outer loop
+      vertex -1.3395662 -2.1108189 10
+      vertex -1.0644474 -2.2620668 0
+      vertex -1.3395662 -2.1108189 0
+    endloop
+  endfacet
+  facet normal -0.36812553 0.9297761 0
+    outer loop
+      vertex 1.0644474 -2.2620668 0
+      vertex 0.772542 -2.3776407 10
+      vertex 1.0644474 -2.2620668 10
+    endloop
+  endfacet
+  facet normal -0.36812553 0.9297761 0
+    outer loop
+      vertex 0.772542 -2.3776407 10
+      vertex 1.0644474 -2.2620668 0
+      vertex 0.772542 -2.3776407 0
+    endloop
+  endfacet
+  facet normal 0.24869105 0.96858287 0
+    outer loop
+      vertex -0.46845245 -2.455718 0
+      vertex -0.772542 -2.3776407 10
+      vertex -0.46845245 -2.455718 10
+    endloop
+  endfacet
+  facet normal 0.24869105 0.96858287 0
+    outer loop
+      vertex -0.772542 -2.3776407 10
+      vertex -0.46845245 -2.455718 0
+      vertex -0.772542 -2.3776407 0
+    endloop
+  endfacet
+  facet normal 0.12533306 0.9921147 0
+    outer loop
+      vertex -0.15697575 -2.4950666 0
+      vertex -0.46845245 -2.455718 10
+      vertex -0.15697575 -2.4950666 10
+    endloop
+  endfacet
+  facet normal 0.12533306 0.9921147 0
+    outer loop
+      vertex -0.46845245 -2.455718 10
+      vertex -0.15697575 -2.4950666 0
+      vertex -0.46845245 -2.455718 0
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
Now we don't depend on OpenSCAD being installed in the host machine, and with that the builds are now hermetic, as we will always use the same binary version