### PR TITLE
Allow using the generated .stl file from a scad_object() rule.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -41,4 +41,5 @@ stardoc(
     name = "docs",
     input = "scad.bzl",
     out = "scad.md",
+    tags = ["manual"],
 )

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
+
 py_library(
     name = "scad_utils",
     srcs = ["scad_utils.py"],
@@ -33,4 +35,10 @@ alias(
         # "@bazel_tools//src/conditions:windows" : ":openscad_windows",
     }),
     visibility = ["//visibility:public"],
+)
+
+stardoc(
+    name = "docs",
+    input = "scad.bzl",
+    out = "scad.md",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,12 @@ module(
     compatibility_level = 0,
 )
 
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.1",
+    dev_dependency = True,
+)
+
 # Here are the files being defined for each OS
 http_appimage = use_repo_rule("//:http_appimage.bzl", "http_appimage")
 http_appimage(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,12 @@ bazel_dep(
     dev_dependency = True,
 )
 
+bazel_dep(
+    name = "stardoc",
+    version = "0.8.0",
+    dev_dependency = True,
+)
+
 # Here are the files being defined for each OS
 http_appimage = use_repo_rule("//:http_appimage.bzl", "http_appimage")
 http_appimage(

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ After this, you can use the rules the same way that you would use any other Baze
 
 ## Rules reference
 
+<a id="scad_library"></a>
+
 ### scad_library
 
 <pre>
@@ -72,7 +74,7 @@ Create a 3D library to wrap OpenSCAD code to be linked by other libraries or obj
 <pre>
 load("@rules_openscad//:scad.bzl", "scad_object")
 
-scad_object(<a href="#scad_object-name">name</a>, <a href="#scad_object-deps">deps</a>, <a href="#scad_object-srcs">srcs</a>)
+scad_object(<a href="#scad_object-name">name</a>, <a href="#scad_object-deps">deps</a>, <a href="#scad_object-srcs">srcs</a>, <a href="#scad_object-out">out</a>)
 </pre>
 
 Create a 3D object based on the provided code and libraries
@@ -85,6 +87,7 @@ Create a 3D object based on the provided code and libraries
 | <a id="scad_object-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="scad_object-deps"></a>deps |  Other libraries that the files on this rule depend on   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="scad_object-srcs"></a>srcs |  Filenames for the files that are included in this rule   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="scad_object-out"></a>out |  The name of the generated file.   | <a href="https://bazel.build/concepts/labels">Label</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
 
 
 <a id="scad_test"></a>

--- a/README.md
+++ b/README.md
@@ -46,43 +46,57 @@ After this, you can use the rules the same way that you would use any other Baze
 ## Rules reference
 
 ### scad_library
+
+<pre>
+load("@rules_openscad//:scad.bzl", "scad_library")
+
+scad_library(<a href="#scad_library-name">name</a>, <a href="#scad_library-deps">deps</a>, <a href="#scad_library-srcs">srcs</a>)
+</pre>
+
 Create a 3D library to wrap OpenSCAD code to be linked by other libraries or objects
 
-|Parameter|Type|Description
-|-|-|-
-|srcs|list[file]|List of files that compile to generate this library
-|deps|list[target]|Other libraries this library depends on
+**ATTRIBUTES**
 
-#### Example library
-```
-scad_library(
-    name = "hollow_cylinder",
-    srcs = ["hollow_cylinder.scad"],
-    deps = [
-        ":some_library",
-    ],
-    visibility = ["//visibility:public"],
-)
-```
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="scad_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="scad_library-deps"></a>deps |  Other libraries that the files on this rule depend on   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="scad_library-srcs"></a>srcs |  Filenames for the files that are included in this rule   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+
+
+<a id="scad_object"></a>
 
 ### scad_object
+
+<pre>
+load("@rules_openscad//:scad.bzl", "scad_object")
+
+scad_object(<a href="#scad_object-name">name</a>, <a href="#scad_object-deps">deps</a>, <a href="#scad_object-srcs">srcs</a>)
+</pre>
+
 Create a 3D object based on the provided code and libraries
 
-|Parameter|Type|Description
-|-|-|-
-|srcs|list[file]|List of files that compile to generate this object
-|deps|list[target]|List of libraries this object depends on
+**ATTRIBUTES**
 
-#### Example object
-```
-scad_object(
-    name = "hollow_cylinder_obj",
-    srcs = ["hollow_cylinder_obj.scad"],
-    deps = [":hollow_cylinder"],
-)
-```
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="scad_object-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="scad_object-deps"></a>deps |  Other libraries that the files on this rule depend on   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="scad_object-srcs"></a>srcs |  Filenames for the files that are included in this rule   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+
+
+<a id="scad_test"></a>
 
 ### scad_test
+
+<pre>
+load("@rules_openscad//:scad.bzl", "scad_test")
+
+scad_test(<a href="#scad_test-name">name</a>, <a href="#scad_test-assertions">assertions</a>, <a href="#scad_test-library_under_test">library_under_test</a>, <a href="#scad_test-tests">tests</a>)
+</pre>
+
 Test for 3D objects and libraries
 
 The test works by compiling the code provided in the tests attribute, and
@@ -93,11 +107,15 @@ defined equal if A-B is empty (B includes A) and B-A is empty (A includes B)
 The test also checks that assertions are triggered for all the code provided in
 the assertions list
 
-|Parameter|Type|Description
-|-|-|-
-|library_under_test|label|Library that will be imported when compiling any code under test
-|tests|dict[label][string]|List of testcases. The key is the filename of the golden STL for this testcase, and the value is the code under test (which object will be compiled) without the library under test being imported (that's done by the framework)<br/><br/>The test will fail if any of the code snippets under test create a result that is different from the golden STL for that testcase</p>
-|assertions|list[string]|List of code snippets that are expected to fail an assertion. The test will fail if any of these fail to trigger an assertion
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="scad_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="scad_test-assertions"></a>assertions |  List of code snippets that are expected to fail an assertion. The test will fail if any of these fail to trigger an assertion   | List of strings | optional |  `[]`  |
+| <a id="scad_test-library_under_test"></a>library_under_test |  Library that will be imported when compiling any code under test   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="scad_test-tests"></a>tests |  List of testcases. The key is the filename of the golden STL for this testcase, and the value is the code under test (which object will be compiled) without the library under test being imported (that's done by the  framework)<br><br>The test will fail if any of the code snippets under test create a result that is different from the golden STL for that testcase   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | required |  |
 
 
 #### Example test

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,2 +1,17 @@
 load("openscad_files.bzl", "define_openscad_versions")
 define_openscad_versions()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()

--- a/scad.bzl
+++ b/scad.bzl
@@ -49,10 +49,6 @@ scad_library = rule(
     },
     doc = """
 Create a 3D library to wrap OpenSCAD code to be linked by other libraries or objects
-
-Args:
-    srcs: (list[file]) List of files that compile to generate this library
-    deps: (list[target]) Other libraries this library depends on
 """,
 )
 
@@ -96,10 +92,6 @@ scad_object = rule(
     },
     doc = """
 Create a 3D object based on the provided code and libraries
-
-Args:
-    srcs: (list[file]) List of files that compile to generate this object
-    deps: (list[target]) List of libraries this object depends on
 """,
 )
 

--- a/scad.bzl
+++ b/scad.bzl
@@ -53,7 +53,10 @@ Create a 3D library to wrap OpenSCAD code to be linked by other libraries or obj
 )
 
 def _scad_object_impl(ctx):
-    stl_output = ctx.actions.declare_file(ctx.label.name + ".stl")
+    if ctx.outputs.out:
+        stl_output = ctx.actions.declare_file(ctx.outputs.out.basename)
+    else:
+        stl_output = ctx.actions.declare_file(ctx.label.name + ".stl")
     stl_inputs = ctx.files.srcs
     deps = []
     for one_transitive_dep in [dep[DefaultInfo].files for dep in ctx.attr.deps]:
@@ -85,6 +88,9 @@ scad_object = rule(
     attrs = {
         "srcs": srcs_attrs,
         "deps": deps_attrs,
+        "out": attr.output(
+            doc = "The name of the generated file.",
+        ),
         "_openscad_files": attr.label(
             default = Label("//:openscad"),
             cfg = "exec",

--- a/scad.bzl
+++ b/scad.bzl
@@ -116,7 +116,7 @@ def _scad_test_impl(ctx):
         content = "#!/bin/bash\n" + " ".join([
             "env; pwd; find -type f; find -type l;",
             unittest_binary.short_path,
-            "--openscad_command '%s'" % _get_openscad_executable(ctx).path,
+            "--openscad_command '%s'" % _get_openscad_executable(ctx).short_path,
             "--scad_file_under_test %s" % ctx.files.library_under_test[0].path,
             " ".join([
                 "--testcases \"%s#%s/%s\"" % (
@@ -143,7 +143,7 @@ def _scad_test_impl(ctx):
                 transitive_files = depset(
                     direct = ctx.files.tests + [unittest_script],
                     transitive = [
-                        ctx.attr.library_under_test.files, 
+                        ctx.attr.library_under_test.files,
                         depset([
                             ctx.attr._unittest_binary[PyRuntimeInfo].interpreter,
                         ]),

--- a/test_models/BUILD
+++ b/test_models/BUILD
@@ -4,6 +4,7 @@ load(
     "scad_object",
     "scad_test",
 )
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 scad_library(
     name = "cylinder_section",
@@ -72,4 +73,13 @@ scad_test(
         "testdata/hollow_cylinder/ed_wt.stl": "HollowCylinder(length=10,external_diameter=3,wall_thickness=0.2)",
         "testdata/hollow_cylinder/id_wt.stl": "HollowCylinder(length=10,internal_diameter=5,wall_thickness=3)",
     },
+)
+
+build_test(
+    name = "objects_build_test",
+    targets = [
+        ":cylinder_section_obj",
+        ":hardware_obj",
+        ":hollow_cylinder_obj",
+    ],
 )

--- a/test_models/BUILD
+++ b/test_models/BUILD
@@ -18,6 +18,13 @@ scad_object(
     deps = [":cylinder_section"],
 )
 
+scad_object(
+    name = "cylinder_section_obj_rename",
+    srcs = ["cylinder_section_obj.scad"],
+    out = "other.stl",
+    deps = [":cylinder_section"],
+)
+
 scad_test(
     name = "cylinder_section_test",
     library_under_test = ":cylinder_section",
@@ -79,6 +86,7 @@ build_test(
     name = "objects_build_test",
     targets = [
         ":cylinder_section_obj",
+        ":other.stl",
         ":hardware_obj",
         ":hollow_cylinder_obj",
     ],

--- a/test_models/MODULE.bazel
+++ b/test_models/MODULE.bazel
@@ -3,3 +3,9 @@ local_path_override(
     module_name = "rules_openscad",
     path = "..",
 )
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.1",
+    dev_dependency = True,
+)

--- a/test_models/WORKSPACE
+++ b/test_models/WORKSPACE
@@ -5,3 +5,18 @@ local_repository(
 
 load("@rules_openscad//:openscad_files.bzl", "define_openscad_versions")
 define_openscad_versions()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()


### PR DESCRIPTION
As it currently stands, the `scad_object()` rule generates two output files and there is no way for another Bazel rule to depend on just one of them. By adding an output attribute that allows setting the file name, the generated `.stl` becomes an "implicit output" which can be directly referenced by other rules.

### Note

I have included the deps for the doc generation in the `MODULE.bazel` but *not* the `WORKSPACE` because [they are a mess](https://github.com/bazelbuild/stardoc/releases/tag/0.8.0) and I _think_ they aren't needed unless you are actually updating the docs.

---
On top of that:
- Tweak to `scad_test()` to make it work on my machine (and I _think_ it will work in general, but I don't have anywhere else I can test it).
- Test the `scad_object()` invocations.
- Generate the documentation.